### PR TITLE
Update model examples and runtime calcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ terraform.rc
 open-notebook
 secrets/*
 !secrets/.gitkeep
+
+# personal hack dev scripts
+hack/dev/

--- a/examples/datasets/k8s-instructions.yaml
+++ b/examples/datasets/k8s-instructions.yaml
@@ -3,6 +3,7 @@ kind: Dataset
 metadata:
   name: k8s-instructions
 spec:
+  filename: k8s-instructions.jsonl
   source:
-    filename: k8s-instructions.jsonl
-    url: https://huggingface.co/datasets/samos123/k8s-instructions/raw/main/k8s-instructions.jsonl
+    git:
+      url: https://github.com/substratusai/dataset-k8s-instructions

--- a/examples/facebook-opt-125m/finetuned-model.yaml
+++ b/examples/facebook-opt-125m/finetuned-model.yaml
@@ -1,17 +1,14 @@
 apiVersion: substratus.ai/v1
 kind: Model
 metadata:
-  name: fb-opt-125m-squad
+  name: fb-opt-125m-k8s-instructions
 spec:
   source:
     modelName: facebook-opt-125m
   training:
-    datasetName: squad
+    datasetName: k8s-instructions
     params:
-      epochs: 3
-      batchSize: 100
-      dataLimit: 1000
-  # TODO: This should be copied from the source Model.
+      epochs: 1
   size:
     parameterBits: 32
     parameterCount: 125000000

--- a/examples/facebook-opt-125m/finetuned-server.yaml
+++ b/examples/facebook-opt-125m/finetuned-server.yaml
@@ -1,6 +1,6 @@
 apiVersion: substratus.ai/v1
 kind: ModelServer
 metadata:
-  name: fb-opt-125m-squad
+  name: fb-opt-125m-k8s-instructions
 spec:
-  modelName: fb-opt-125m-squad
+  modelName: fb-opt-125m-k8s-instructions

--- a/examples/facebook-opt-125m/model.yaml
+++ b/examples/facebook-opt-125m/model.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   source:
     git:
-      url: https://github.com/substratusai/model-facebook-opt-125m
-      branch: params
+      url: https://github.com/substratusai/model-facebook-opt-125m-hf
+      branch: main
   size:
     parameterBits: 32
     parameterCount: 125000000

--- a/examples/falcon-40b-instruct/model.yaml
+++ b/examples/falcon-40b-instruct/model.yaml
@@ -7,7 +7,7 @@ spec:
     git:
       url: https://github.com/substratusai/model-falcon-40b-instruct
   size:
-    parameterBits: 8
+    parameterBits: 16
     parameterCount: 40000000000
   compute:
     types: ["GPU"]

--- a/examples/falcon-40b-instruct/model.yaml
+++ b/examples/falcon-40b-instruct/model.yaml
@@ -5,10 +5,9 @@ metadata:
 spec:
   source:
     git:
-      url: https://github.com/substratusai/models
-      path: falcon-40b-instruct
+      url: https://github.com/substratusai/model-falcon-40b-instruct
   size:
-    parameterBits: 16
+    parameterBits: 8
     parameterCount: 40000000000
   compute:
     types: ["GPU"]

--- a/examples/falcon-40b/finetuned-model.yaml
+++ b/examples/falcon-40b/finetuned-model.yaml
@@ -1,0 +1,12 @@
+apiVersion: substratus.ai/v1
+kind: Model
+metadata:
+  name: falcon-40b-k8s-instruct
+spec:
+  source:
+    modelName: falcon-40b
+  training:
+    datasetName: k8s-instructions
+  size:
+    parameterBits: 4
+    parameterCount: 40000000000

--- a/examples/falcon-40b/finetuned-model.yaml
+++ b/examples/falcon-40b/finetuned-model.yaml
@@ -8,5 +8,5 @@ spec:
   training:
     datasetName: k8s-instructions
   size:
-    parameterBits: 4
+    parameterBits: 8
     parameterCount: 40000000000

--- a/examples/falcon-40b/finetuned-model.yaml
+++ b/examples/falcon-40b/finetuned-model.yaml
@@ -8,5 +8,5 @@ spec:
   training:
     datasetName: k8s-instructions
   size:
-    parameterBits: 8
+    parameterBits: 16
     parameterCount: 40000000000

--- a/examples/falcon-40b/model.yaml
+++ b/examples/falcon-40b/model.yaml
@@ -1,0 +1,11 @@
+apiVersion: substratus.ai/v1
+kind: Model
+metadata:
+  name: falcon-40b
+spec:
+  source:
+    git:
+      url: github.com/substratusai/model-falcon-40b
+  size:
+    parameterBits: 4
+    parameterCount: 40000000000

--- a/examples/falcon-40b/model.yaml
+++ b/examples/falcon-40b/model.yaml
@@ -7,7 +7,7 @@ spec:
     git:
       url: https://github.com/substratusai/model-falcon-40b
   size:
-    parameterBits: 8
+    parameterBits: 16
     parameterCount: 40000000000
   compute:
     types: ["GPU"]

--- a/examples/falcon-40b/model.yaml
+++ b/examples/falcon-40b/model.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   source:
     git:
-      url: github.com/substratusai/model-falcon-40b
+      url: https://github.com/substratusai/model-falcon-40b
   size:
     parameterBits: 8
     parameterCount: 40000000000

--- a/examples/falcon-40b/model.yaml
+++ b/examples/falcon-40b/model.yaml
@@ -7,5 +7,5 @@ spec:
     git:
       url: github.com/substratusai/model-falcon-40b
   size:
-    parameterBits: 4
+    parameterBits: 8
     parameterCount: 40000000000

--- a/examples/falcon-40b/model.yaml
+++ b/examples/falcon-40b/model.yaml
@@ -9,3 +9,5 @@ spec:
   size:
     parameterBits: 8
     parameterCount: 40000000000
+  compute:
+    types: ["GPU"]

--- a/examples/falcon-40b/notebook.yaml
+++ b/examples/falcon-40b/notebook.yaml
@@ -1,0 +1,6 @@
+apiVersion: substratus.ai/v1
+kind: Notebook
+metadata:
+  name: falcon-40b
+spec:
+  modelName: falcon-40b

--- a/examples/falcon-40b/server.yaml
+++ b/examples/falcon-40b/server.yaml
@@ -1,0 +1,6 @@
+apiVersion: substratus.ai/v1
+kind: ModelServer
+metadata:
+  name: falcon-40b
+spec:
+  modelName: falcon-40b

--- a/examples/falcon-7b-instruct/finetuned-model.yaml
+++ b/examples/falcon-7b-instruct/finetuned-model.yaml
@@ -1,9 +1,16 @@
 apiVersion: substratus.ai/v1
 kind: Model
 metadata:
-  name: my-model
+  name: falcon-7b-instruct-k8s
 spec:
   source:
     modelName: falcon-7b-instruct
   training:
     datasetName: k8s-instructions
+    params:
+      epochs: 1
+  size:
+    parameterBits: 16
+    parameterCount: 7000000000
+  compute:
+    types: ["GPU"]

--- a/examples/falcon-7b-instruct/finetuned-notebook.yaml
+++ b/examples/falcon-7b-instruct/finetuned-notebook.yaml
@@ -1,0 +1,7 @@
+apiVersion: substratus.ai/v1
+kind: Notebook
+metadata:
+  name: falcon-7b-instruct-k8s
+spec:
+  suspend: true
+  modelName: falcon-7b-instruct-k8s

--- a/examples/falcon-7b-instruct/finetuned-server.yaml
+++ b/examples/falcon-7b-instruct/finetuned-server.yaml
@@ -1,6 +1,6 @@
 apiVersion: substratus.ai/v1
 kind: ModelServer
 metadata:
-  name: my-model-server
+  name: falcon-7b-instruct-k8s
 spec:
-  modelName: my-model
+  modelName: falcon-7b-instruct-k8s

--- a/examples/falcon-7b-instruct/notebook.yaml
+++ b/examples/falcon-7b-instruct/notebook.yaml
@@ -1,0 +1,6 @@
+apiVersion: substratus.ai/v1
+kind: Notebook
+metadata:
+  name: falcon-7b-instruct
+spec:
+  modelName: falcon-7b-instruct

--- a/install/scripts/gcp-up.sh
+++ b/install/scripts/gcp-up.sh
@@ -10,6 +10,7 @@ set -u
 export CLOUDSDK_AUTH_ACCESS_TOKEN=${TOKEN}
 # Used by terraform:
 export GOOGLE_OAUTH_ACCESS_TOKEN=${TOKEN}
+INSTALL_OPERATOR="${INSTALL_OPERATOR:-yes}"
 
 # Enable required services.
 gcloud services enable --project ${PROJECT} container.googleapis.com
@@ -37,7 +38,10 @@ cd -
 gcloud container clusters get-credentials --project ${PROJECT} --region ${cluster_region} ${cluster_name}
 # Install nvidia driver
 kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+
 # Install cluster components.
-kubectl apply -f kubernetes/namespace.yaml
-kubectl apply -f kubernetes/config.yaml
-kubectl apply -f kubernetes/system.yaml
+if [ "$INSTALL_OPERATOR" == "yes" ]; then
+  kubectl apply -f kubernetes/namespace.yaml
+  kubectl apply -f kubernetes/config.yaml
+  kubectl apply -f kubernetes/system.yaml
+fi

--- a/install/terraform/gcp/cluster.tf
+++ b/install/terraform/gcp/cluster.tf
@@ -85,12 +85,12 @@ resource "google_container_cluster" "main" {
     resource_limits {
       resource_type = "cpu"
       minimum       = 0
-      maximum       = 9600
+      maximum       = 960
     }
     resource_limits {
       resource_type = "memory"
       minimum       = 0
-      maximum       = 104800
+      maximum       = 10480
     }
     # from https://cloud.google.com/compute/docs/gpus/#nvidia_gpus_for_compute_workloads
     # TODO(bjb): ideally set these to align with regional quota on the project

--- a/install/terraform/gcp/cluster.tf
+++ b/install/terraform/gcp/cluster.tf
@@ -85,55 +85,55 @@ resource "google_container_cluster" "main" {
     resource_limits {
       resource_type = "cpu"
       minimum       = 0
-      maximum       = 96
+      maximum       = 9600
     }
     resource_limits {
       resource_type = "memory"
       minimum       = 0
-      maximum       = 1048
+      maximum       = 104800
     }
     # from https://cloud.google.com/compute/docs/gpus/#nvidia_gpus_for_compute_workloads
     # TODO(bjb): ideally set these to align with regional quota on the project
     resource_limits {
       resource_type = "nvidia-l4"
       minimum       = 0
-      maximum       = 8
+      maximum       = 80
     }
     resource_limits {
       resource_type = "nvidia-tesla-a100" # 40gb
       minimum       = 0
-      maximum       = 8
+      maximum       = 80
     }
     resource_limits {
       resource_type = "nvidia-a100-80gb"
       minimum       = 0
-      maximum       = 8
+      maximum       = 80
     }
     resource_limits {
       resource_type = "nvidia-tesla-t4"
       minimum       = 0
-      maximum       = 8
+      maximum       = 80
     }
     resource_limits {
       resource_type = "nvidia-tesla-v100"
       minimum       = 0
-      maximum       = 8
+      maximum       = 80
     }
     resource_limits {
       resource_type = "nvidia-tesla-p100"
       minimum       = 0
-      maximum       = 8
+      maximum       = 80
     }
     resource_limits {
       resource_type = "nvidia-tesla-p4"
       minimum       = 0
-      maximum       = 8
+      maximum       = 80
     }
     # EOL on GCP May 1, 2024: https://cloud.google.com/compute/docs/eol/k80-eol
     resource_limits {
       resource_type = "nvidia-tesla-k80"
       minimum       = 0
-      maximum       = 8
+      maximum       = 80
     }
   }
 

--- a/internal/controller/runtime.go
+++ b/internal/controller/runtime.go
@@ -133,8 +133,13 @@ loop:
 
 		// GPU
 		if gpu != nil {
+			// Training requires more memory. For now use double the amount of GPUs
+			if runtime == RuntimeNotebook || runtime == RuntimeTrainer {
+				gpuCount = gpuCount * 2
+			}
 			resources.Requests[gpu.ResourceName] = *resource.NewQuantity(gpuCount, resource.DecimalSI)
 			resources.Limits[gpu.ResourceName] = *resource.NewQuantity(gpuCount, resource.DecimalSI)
+
 			if spec.NodeSelector == nil {
 				spec.NodeSelector = map[string]string{}
 			}

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -44,7 +44,7 @@ func Test_setRuntimeResources(t *testing.T) {
 				},
 			},
 			expected: map[Runtime]expectation{
-				RuntimeTrainer: expectation{spec: `
+				RuntimeTrainer: {spec: `
 containers:
 - name: trainer
   resources:
@@ -53,7 +53,7 @@ containers:
       ephemeral-storage: 100Gi
       memory: 3Gi
 				`},
-				RuntimeNotebook: expectation{spec: `
+				RuntimeNotebook: {spec: `
 containers:
 - name: notebook
   resources:
@@ -62,7 +62,7 @@ containers:
       ephemeral-storage: 100Gi
       memory: 3Gi
 				`},
-				RuntimeServer: expectation{spec: `
+				RuntimeServer: {spec: `
 containers:
 - name: server
   resources:
@@ -71,7 +71,7 @@ containers:
       ephemeral-storage: 100Gi
       memory: 3Gi
 				`},
-				RuntimeBuilder: expectation{spec: `
+				RuntimeBuilder: {spec: `
 containers:
 - name: builder
   resources:
@@ -97,17 +97,17 @@ containers:
 				},
 			},
 			expected: map[Runtime]expectation{
-				RuntimeTrainer: expectation{spec: `
+				RuntimeTrainer: {spec: `
 containers:
 - name: trainer
   resources:
     limits:
-      nvidia.com/gpu: "1"
+      nvidia.com/gpu: "2"
     requests:
       cpu: "2"
       ephemeral-storage: 100Gi
       memory: 3Gi
-      nvidia.com/gpu: "1"
+      nvidia.com/gpu: "2"
 nodeSelector:
   cloud.google.com/gke-accelerator: nvidia-l4
   cloud.google.com/gke-spot: "true"
@@ -117,17 +117,17 @@ tolerations:
   operator: Equal
   value: "true"
 				`},
-				RuntimeNotebook: expectation{spec: `
+				RuntimeNotebook: {spec: `
 containers:
 - name: notebook
   resources:
     limits:
-      nvidia.com/gpu: "1"
+      nvidia.com/gpu: "2"
     requests:
       cpu: "2"
       ephemeral-storage: 100Gi
       memory: 3Gi
-      nvidia.com/gpu: "1"
+      nvidia.com/gpu: "2"
 nodeSelector:
   cloud.google.com/gke-accelerator: nvidia-l4
   cloud.google.com/gke-spot: "true"
@@ -137,7 +137,7 @@ tolerations:
   operator: Equal
   value: "true"
 				`},
-				RuntimeServer: expectation{spec: `
+				RuntimeServer: {spec: `
 containers:
 - name: server
   resources:
@@ -157,7 +157,7 @@ tolerations:
   operator: Equal
   value: "true"
 				`},
-				RuntimeBuilder: expectation{spec: `
+				RuntimeBuilder: {spec: `
 containers:
 - name: builder
   resources:
@@ -183,17 +183,17 @@ containers:
 				},
 			},
 			expected: map[Runtime]expectation{
-				RuntimeTrainer: expectation{spec: `
+				RuntimeTrainer: {spec: `
 containers:
 - name: trainer
   resources:
     limits:
-      nvidia.com/gpu: "1"
+      nvidia.com/gpu: "2"
     requests:
       cpu: "2"
       ephemeral-storage: 100Gi
       memory: 17Gi
-      nvidia.com/gpu: "1"
+      nvidia.com/gpu: "2"
 nodeSelector:
   cloud.google.com/gke-accelerator: nvidia-l4
   cloud.google.com/gke-spot: "true"
@@ -203,17 +203,17 @@ tolerations:
   operator: Equal
   value: "true"
 				`},
-				RuntimeNotebook: expectation{spec: `
+				RuntimeNotebook: {spec: `
 containers:
 - name: notebook
   resources:
     limits:
-      nvidia.com/gpu: "1"
+      nvidia.com/gpu: "2"
     requests:
       cpu: "2"
       ephemeral-storage: 100Gi
       memory: 17Gi
-      nvidia.com/gpu: "1"
+      nvidia.com/gpu: "2"
 nodeSelector:
   cloud.google.com/gke-accelerator: nvidia-l4
   cloud.google.com/gke-spot: "true"
@@ -223,7 +223,7 @@ tolerations:
   operator: Equal
   value: "true"
 				`},
-				RuntimeServer: expectation{spec: `
+				RuntimeServer: {spec: `
 containers:
 - name: server
   resources:
@@ -243,7 +243,7 @@ tolerations:
   operator: Equal
   value: "true"
 				`},
-				RuntimeBuilder: expectation{spec: `
+				RuntimeBuilder: {spec: `
 containers:
 - name: builder
   resources:
@@ -274,7 +274,7 @@ containers:
 				},
 			},
 			expected: map[Runtime]expectation{
-				RuntimeBuilder: expectation{
+				RuntimeBuilder: {
 					spec: `
 containers:
 - name: builder


### PR DESCRIPTION
* Double the amount of GPUs for training and notebooks
* Point facebook-opt-125m to the huggingface library based model that also has basaran
* Add notebook examples for falcon models
* Add option to disable installing the operator during gcp-up.sh call. Use env variable INSTALL_OPERATOR=no with default being yes (undocumented only for development would set to no)
* Increase resource limits by 10x so you can create up to 10 nodes of a certain type