### PR TITLE
add goreleaser and actions config

### DIFF
--- a/.github/workflows/publish-kubectl-plugin.yaml
+++ b/.github/workflows/publish-kubectl-plugin.yaml
@@ -1,0 +1,34 @@
+name: goreleaser
+on:
+  push:
+    tags:
+      - "*"
+permissions:
+  contents: write
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+      - name: Upload assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: kubectl-plugin
+          path: |
+            dist/*
+            !dist/artifacts.json
+            !dist/metadata.yaml
+            !dist/config.yaml
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ secrets/*
 
 # personal hack dev scripts
 hack/dev/
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,44 @@
+project_name: kubectl-open-notebook
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+builds:
+  - main: ./kubectl/open-notebook/
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - ppc64le
+archives:
+  - id: archive
+    format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/config/crd/bases/substratus.ai_datasets.yaml
+++ b/config/crd/bases/substratus.ai_datasets.yaml
@@ -57,7 +57,7 @@ spec:
                 description: Filename is the name of the file when it is downloaded.
                 type: string
               source:
-                description: Source if a reference to the code that is doing the data
+                description: Source is a reference to the code that is doing the data
                   sourcing.
                 properties:
                   git:

--- a/docs/kubectl-plugins.md
+++ b/docs/kubectl-plugins.md
@@ -18,11 +18,11 @@ kubectl open notebook -f notebook.yaml
 
 Release binaries are created for most architectures when the repo is tagged.
 [Identify the release](https://github.com/substratusai/substratus/releases) you
-want to use and replace the value of RELEASE in the command below:
+want to use and replace the value of RELEASE in the command below. Note, moving
+the binary to your path :
 
 ```sh
-RELEASE="v0.4.0-alpha" wget -qO- $(uname -sm | awk -v release="$RELEASE" '{print "https://github.com/substratusai/substratus/releases/download/" release "/kubectl-open-notebook_" $1 "_" $2 ".tar.gz"}') | tar zxv && \
-sudo mv kubectl-open-notebook /usr/local/bin/
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/substratusai/substratus/main/hack/install_kubectl_plugin.sh)"
 ```
 
 If the plugin installed correctly, you should see it listed as a `kubectl plugin`:

--- a/docs/kubectl-plugins.md
+++ b/docs/kubectl-plugins.md
@@ -4,7 +4,8 @@
 
 `kubectl open notebook`
 
-Starts and opens a Jupyter Notebook in the user's browser. Will suspend the Notebook (delete the running Pod) upon cancelling the command.
+Starts and opens a Jupyter Notebook in the user's browser. Will suspend the
+Notebook (delete the running Pod) upon cancelling the command.
 
 Examples:
 
@@ -17,9 +18,9 @@ kubectl open notebook -f notebook.yaml
 ### Installation
 
 Release binaries are created for most architectures when the repo is tagged.
-[Identify the release](https://github.com/substratusai/substratus/releases) you
-want to use and replace the value of RELEASE in the command below. Note, moving
-the binary to your path :
+Be aware that moving the binary to your PATH might fail due to permissions
+(observed on mac). If it fails, the script will retry the `mv` with `sudo` and
+prompt you for your password:
 
 ```sh
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/substratusai/substratus/main/hack/install_kubectl_plugin.sh)"

--- a/docs/kubectl-plugins.md
+++ b/docs/kubectl-plugins.md
@@ -14,10 +14,23 @@ kubectl open notebook -n my-namespace my-nb-name
 kubectl open notebook -f notebook.yaml
 ```
 
-Install with:
+### Installation
+
+Clone the repo:
 
 ```sh
-# TODO: Install from GitHub release.
-go build ./kubectl/open-notebook && mv open-notebook /usr/local/bin/kubectl-open-notebook
+git clone https://github.com/substratusai/substratus && cd substratus
 ```
 
+Install the binary:
+
+```sh
+go build ./kubectl/open-notebook
+sudo mv open-notebook /usr/local/bin/kubectl-open-notebook
+```
+
+If the plugin installed correctly, you should see it listed as a `kubectl plugin`:
+
+```sh
+kubectl plugin list 2>/dev/null | grep kubectl-open-notebook
+```

--- a/docs/kubectl-plugins.md
+++ b/docs/kubectl-plugins.md
@@ -16,17 +16,13 @@ kubectl open notebook -f notebook.yaml
 
 ### Installation
 
-Clone the repo:
+Release binaries are created for most architectures when the repo is tagged.
+[Identify the release](https://github.com/substratusai/substratus/releases) you
+want to use and replace the value of RELEASE in the command below:
 
 ```sh
-git clone https://github.com/substratusai/substratus && cd substratus
-```
-
-Install the binary:
-
-```sh
-go build ./kubectl/open-notebook
-sudo mv open-notebook /usr/local/bin/kubectl-open-notebook
+RELEASE="v0.4.0-alpha" wget -qO- $(uname -sm | awk -v release="$RELEASE" '{print "https://github.com/substratusai/substratus/releases/download/" release "/kubectl-open-notebook_" $1 "_" $2 ".tar.gz"}') | tar zxv && \
+sudo mv kubectl-open-notebook /usr/local/bin/
 ```
 
 If the plugin installed correctly, you should see it listed as a `kubectl plugin`:

--- a/go.mod
+++ b/go.mod
@@ -4,22 +4,20 @@ go 1.19
 
 require (
 	cloud.google.com/go v0.65.0
+	github.com/briandowns/spinner v1.23.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
-	k8s.io/klog/v2 v2.80.1
 	sigs.k8s.io/controller-runtime v0.14.4
 	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/briandowns/spinner v1.23.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
@@ -59,6 +57,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/net v0.3.1-0.20221206200815-1e63c2f08a10 // indirect
+	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/term v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect
@@ -71,6 +70,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect
+	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect

--- a/hack/install_kubectl_plugin.sh
+++ b/hack/install_kubectl_plugin.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -xe
+
+REPO='https://github.com/substratusai/substratus'
+LATEST_RELEASE=$(curl ${REPO}/releases -s |
+  grep 'Link--primary' |
+  head -n1 |
+  perl -n -e '/v([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?)/ && print $&')
+OS=$(uname -s)
+ARCH=$(uname -m | sed 's/aarch64/arm64/g')
+LATEST_ARTIFACT_URL=$(echo $LATEST_RELEASE | awk -v repo=$REPO -v os=$OS -v arch=$ARCH -v release=$LATEST_RELEASE '{print repo "/releases/download/" release "/kubectl-open-notebook_" os "_" arch ".tar.gz"}')
+
+wget -qO- ${LATEST_ARTIFACT_URL} | tar zxv
+chmod +x kubectl-open-notebook
+mv kubectl-open-notebook /usr/local/bin/ || sudo mv kubectl-open-notebook /usr/local/bin/


### PR DESCRIPTION
## What is this change?

This change uses goreleaser in our actions pipeline when we tag new releases, creating a set of kubectl plugin binaries for different architectures.

## Why make this change?

I want to make the install of the plugin as simple as possible - ideally not requiring users to clone our repo.

While developing the vscode extension functionality to create a Notebook via a single command, users are likely to hit a snag if we're relying on both `kubectl` and our kubectl plugin installed locally. The best experience here is likely handling notebook creation and port forwarding through the vscode extension, but to keep it simple and until we get that user feedback, I'll stick to using the plugin shipped here. The plugin install process needed to be ironed out anyway.