### PR TITLE
dockerhub gcp-manager deployment fix + adds skaffold template and makefile targets to install and use it on gcpmanager

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           images: substratusai/controller-manager
       - name: Build and push
+        id: build-and-push-controller-manager
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -41,10 +42,11 @@ jobs:
         with:
           images: substratusai/gcp-manager
       - name: Build and push
+        id: build-and-push-gcp-manager
         uses: docker/build-push-action@v4
         with:
           context: .
-          dockerfile: Dockerfile.gcpmanager
+          file: Dockerfile.gcpmanager
           platforms: "linux/amd64"
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-gcp-manager.outputs.tags }}
@@ -55,6 +57,7 @@ jobs:
         with:
           images: substratusai/installer
       - name: Build and push
+        id: build-and-push-installer
         uses: docker/build-push-action@v4
         with:
           context: install/

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ secrets/*
 # personal hack dev scripts
 hack/dev/
 dist/
+gcpmanager-skaffold.yaml

--- a/Dockerfile.gcpmanager
+++ b/Dockerfile.gcpmanager
@@ -19,6 +19,7 @@ WORKDIR /
 
 # Copy the Pre-built binary file from the previous stage
 COPY --from=builder /workspace/main .
+# use nobody:nogroup
 USER 65532:65532
 EXPOSE 10080
 

--- a/cmd/gcpmanager/main_test.go
+++ b/cmd/gcpmanager/main_test.go
@@ -15,20 +15,17 @@ package main_test
 // curl -v -X PUT -H "Content-Type: application/octet-stream" --upload-file README.md $url
 
 // the following function was successfully used to exercise gcpmanager.Server.CreateSignedURL()
-// func invokeManually(storageClient *storage.Client) {
+// func invokeManually(s *gcpmanager.Server) {
 // 	payload := sci.CreateSignedURLRequest{
-// 		BucketName:        "substr-models1",
+// 		BucketName:        "substratus-ai-001-substratus-notebooks",
 // 		ObjectName:        "README.md",
 // 		ExpirationSeconds: 600,
 // 	}
-// 	serv := gcpmanager.Server{
-// 		StorageClient: storageClient,
-// 	}
 // 	fmt.Println("calling CreateSignedURL with payload:")
 
-//		resp, err := serv.CreateSignedURL(context.Background(), &payload)
-//		if err != nil {
-//			log.Fatalf("failed to create signed URL: %v", err)
-//		}
-//		fmt.Printf("signed URL: %v\n", resp.Url)
-//	}
+// 	resp, err := s.CreateSignedURL(context.Background(), &payload)
+// 	if err != nil {
+// 		log.Fatalf("failed to create signed URL: %v", err)
+// 	}
+// 	fmt.Printf("signed URL: %v\n", resp.Url)
+// }

--- a/config/gcpmanager/gcp-manager.yaml
+++ b/config/gcpmanager/gcp-manager.yaml
@@ -24,7 +24,8 @@ spec:
       containers:
         - name: gcp-manager
           image: us-central1-docker.pkg.dev/substratus-ai-001/substratus/gcpmanager:latest
-          # image: substratusai/gcp-manager:latest
+          # image: substratusai/gcp-manager:main
+          imagePullPolicy: Always
           ports:
             - containerPort: 10080
           resources:

--- a/config/gcpmanager/gcpmanager-skaffold.yaml.tpl
+++ b/config/gcpmanager/gcpmanager-skaffold.yaml.tpl
@@ -1,0 +1,31 @@
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: gcpmanager
+  labels: {}
+build:
+  tagPolicy:
+    gitCommit: {}
+  platforms: ["linux/amd64", "darwin/arm64"]
+  cluster:
+    resources:
+      requests:
+        cpu: 300m
+        memory: 512Mi
+    serviceAccount: container-builder
+  artifacts:
+    - image: us-central1-docker.pkg.dev/${PROJECT_ID}/substratus/gcpmanager
+      # - image: substratusai/gcp-manager
+      kaniko:
+        dockerfile: Dockerfile.gcpmanager
+        logFormat: text
+        logTimestamp: true
+        reproducible: true
+        useNewRun: true
+        verbosity: info
+        cache:
+          ttl: "24h"
+manifests:
+  rawYaml:
+    - "config/gcpmanager/gcp-manager.yaml"
+    - "config/gcpmanager/bootstrapper-job.yaml"


### PR DESCRIPTION
## What is this change?

Two part change:
1. fixes (hopefully) the docker action pushing the gcp-manager to dockerhub
2. adds skaffold as a means of developing gcpmanager locally and deploying it continuously to a remote cluster.

## Why make this change?

I was wanting ways to test the service rapidly and ran into all sorts of issues and long, inefficient cycles. It also showed me the bug here! This smooths over a lot of that pain with a single build and deployment command.

Usage example:
```
➜  substratus git:(feat/add-gcp-manager-skaffold) ✗ make skaffold-dev-gcpmanager
Generating tags...
 - us-central1-docker.pkg.dev/substratus-ai-001/substratus/gcpmanager -> us-central1-docker.pkg.dev/substratus-ai-001/substratus/gcpmanager:v0.4.0-alpha-9-g003fc2e-dirty
Checking cache...
 - us-central1-docker.pkg.dev/substratus-ai-001/substratus/gcpmanager: Found Remotely
Tags used in deployment:
 - us-central1-docker.pkg.dev/substratus-ai-001/substratus/gcpmanager -> us-central1-docker.pkg.dev/substratus-ai-001/substratus/gcpmanager:v0.4.0-alpha-9-g003fc2e-dirty@sha256:5dc50e98d6823dc493dda63f6243dca0e16c356541e6d915b4e49e9564bc90e0
Starting deploy...
 - "gcp-manager" is marked for deletion, waiting for completion
 - serviceaccount/gcp-manager created
 - deployment.apps/gcp-manager created
 - service/gcp-manager created
 - serviceaccount/gcp-manager-bootstrapper created
 - role.rbac.authorization.k8s.io/service-account-annotator created
 - rolebinding.rbac.authorization.k8s.io/service-account-annotator-binding created
 - job.batch/annotate-gcp-manager-sa created
Waiting for deployments to stabilize...
 - substratus:deployment/gcp-manager is ready.
Deployments stabilized in 2.019 seconds
Listing files to watch...
 - us-central1-docker.pkg.dev/substratus-ai-001/substratus/gcpmanager
Press Ctrl+C to exit
Watching for changes...

^CCleaning up...
 - serviceaccount "gcp-manager" deleted
 - deployment.apps "gcp-manager" deleted
 - service "gcp-manager" deleted
 - serviceaccount "gcp-manager-bootstrapper" deleted
 - role.rbac.authorization.k8s.io "service-account-annotator" deleted
 - rolebinding.rbac.authorization.k8s.io "service-account-annotator-binding" deleted
 - job.batch "annotate-gcp-manager-sa" deleted
```