### PR TITLE
fix broken installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= docker.io/substratusai/controller-manager:v0.4.1-alpha
+IMG ?= docker.io/substratusai/controller-manager:v0.4.2-alpha
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26.1
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
-  - manager.yaml
+- manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: controller
-    newName: docker.io/substratusai/controller-manager
-    newTag: v0.4.1-alpha
+- name: controller
+  newName: docker.io/substratusai/controller-manager
+  newTag: v0.4.2-alpha

--- a/examples/falcon-7b-instruct/base-model.yaml
+++ b/examples/falcon-7b-instruct/base-model.yaml
@@ -4,6 +4,6 @@ metadata:
   name: falcon-7b-instruct
 spec:
   image:
-    name: substratusai/model-loader-huggingface
+    name: substratusai/model-loader-huggingface:v0.1.1
   params:
     name: tiiuae/falcon-7b-instruct

--- a/install/kubernetes/system.yaml
+++ b/install/kubernetes/system.yaml
@@ -9,225 +9,238 @@ spec:
   group: substratus.ai
   names:
     categories:
-      - ai
+    - ai
     kind: Dataset
     listKind: DatasetList
     plural: datasets
     singular: dataset
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.ready
-          name: Ready
-          type: boolean
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description:
-            "The Dataset API is used to describe data that can be referenced
-            for training Models. \n - Datasets pull in remote data sources using containerized
-            data loaders. \n - Users can specify their own ETL logic by referencing
-            a repository from a Dataset. \n - Users can leverage pre-built data loader
-            integrations with various sources. \n - Training typically requires a large
-            dataset. The Dataset API pulls a dataset once and stores it in a bucket,
-            which is mounted directly into training Jobs. \n - The Dataset API allows
-            users to query ready-to-use datasets (`kubectl get datasets`). \n - The
-            Dataset API allows Kubernetes RBAC to be applied as a mechanism for controlling
-            access to data."
-          properties:
-            apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-              type: string
-            kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec is the desired state of the Dataset.
-              properties:
-                command:
-                  description: Command to run in the container.
-                  items:
-                    type: string
-                  type: array
-                filename:
-                  description: Filename is the name of the file when it is downloaded.
+  - additionalPrinterColumns:
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "The Dataset API is used to describe data that can be referenced
+          for training Models. \n - Datasets pull in remote data sources using containerized
+          data loaders. \n - Users can specify their own ETL logic by referencing
+          a repository from a Dataset. \n - Users can leverage pre-built data loader
+          integrations with various sources. \n - Training typically requires a large
+          dataset. The Dataset API pulls a dataset once and stores it in a bucket,
+          which is mounted directly into training Jobs. \n - The Dataset API allows
+          users to query ready-to-use datasets (`kubectl get datasets`). \n - The
+          Dataset API allows Kubernetes RBAC to be applied as a mechanism for controlling
+          access to data."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the desired state of the Dataset.
+            properties:
+              command:
+                description: Command to run in the container.
+                items:
                   type: string
-                image:
-                  description: Image that contains dataset loading code and dependencies.
-                  properties:
-                    git:
-                      description:
-                        Git is a reference to a git repository that will
-                        be built within the cluster. Built image will be set in the
-                        Image field.
-                      properties:
-                        branch:
-                          description: Branch is the git branch to use.
-                          type: string
-                        path:
-                          description:
-                            Path within the git repository referenced by
-                            url.
-                          type: string
-                        url:
-                          description: "URL to the git repository. Example: https://github.com/my-username/my-repo"
-                          type: string
-                      required:
-                        - url
-                      type: object
-                    name:
-                      description: 'Name of container image (example: "docker.io/your-username/your-image").'
-                      type: string
-                  type: object
-                params:
-                  additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    x-kubernetes-int-or-string: true
-                  description:
-                    Params will be passed into the loading process as environment
-                    variables.
-                  type: object
-                resources:
-                  description: Resources are the compute resources required by the container.
-                  properties:
-                    cpu:
-                      default: 2
-                      description: CPU resources.
-                      format: int64
-                      type: integer
-                    disk:
-                      default: 10
-                      description: Disk size in Gigabytes.
-                      format: int64
-                      type: integer
-                    gpu:
-                      description: GPU resources.
-                      properties:
-                        count:
-                          description: Count is the number of GPUs.
-                          format: int64
-                          type: integer
-                        type:
-                          description: Type of GPU.
-                          type: string
-                      type: object
-                    memory:
-                      default: 10
-                      description: Memory is the amount of RAM in Gigabytes.
-                      format: int64
-                      type: integer
-                  type: object
-              required:
-                - filename
-                - image
-              type: object
-            status:
-              description: Status is the observed state of the Dataset.
-              properties:
-                conditions:
-                  description:
-                    Conditions is the list of conditions that describe the
-                    current state of the Dataset.
-                  items:
-                    description:
-                      "Condition contains details for one aspect of the current
-                      state of this API Resource. --- This struct is intended for direct
-                      use as an array at the field path .status.conditions.  For example,
-                      \n type FooStatus struct{ // Represents the observations of a
-                      foo's current state. // Known .status.conditions.type are: \"Available\",
-                      \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                      // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                      `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                      protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                type: array
+              filename:
+                description: Filename is the name of the file when it is downloaded.
+                type: string
+              image:
+                description: Image that contains dataset loading code and dependencies.
+                properties:
+                  git:
+                    description: Git is a reference to a git repository that will
+                      be built within the cluster. Built image will be set in the
+                      Image field.
                     properties:
-                      lastTransitionTime:
-                        description:
-                          lastTransitionTime is the last time the condition
-                          transitioned from one status to another. This should be when
-                          the underlying condition changed.  If that is not known, then
-                          using the time when the API field changed is acceptable.
-                        format: date-time
+                      branch:
+                        description: Branch is the git branch to use.
                         type: string
-                      message:
-                        description:
-                          message is a human readable message indicating
-                          details about the transition. This may be an empty string.
-                        maxLength: 32768
+                      path:
+                        description: Path within the git repository referenced by
+                          url.
                         type: string
-                      observedGeneration:
-                        description:
-                          observedGeneration represents the .metadata.generation
-                          that the condition was set based upon. For instance, if .metadata.generation
-                          is currently 12, but the .status.conditions[x].observedGeneration
-                          is 9, the condition is out of date with respect to the current
-                          state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description:
-                          reason contains a programmatic identifier indicating
-                          the reason for the condition's last transition. Producers
-                          of specific condition types may define expected values and
-                          meanings for this field, and whether the values are considered
-                          a guaranteed API. The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description:
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          --- Many .condition.type values are consistent across resources
-                          like Available, but because arbitrary conditions can be useful
-                          (see .node.status.conditions), the ability to deconflict is
-                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      url:
+                        description: 'URL to the git repository. Example: https://github.com/my-username/my-repo'
                         type: string
                     required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                    - url
                     type: object
-                  type: array
-                ready:
-                  default: false
-                  description:
-                    Ready indicates that the Dataset is ready to use. See
-                    Conditions for more details.
-                  type: boolean
-                url:
-                  description: URL of the loaded data.
-                  type: string
-              required:
-                - ready
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                  name:
+                    description: 'Name of container image (example: "docker.io/your-username/your-image").'
+                    type: string
+                  upload:
+                    description: Upload is a signal that a local tar of the directory
+                      should be uploaded to be built as an image.
+                    properties:
+                      md5checksum:
+                        description: Md5Checksum is the md5 checksum of the tar'd
+                          repo root requested to be uploaded and built.
+                        maxLength: 32
+                        minLength: 32
+                        pattern: ^[a-fA-F0-9]{32}$
+                        type: string
+                    type: object
+                type: object
+              params:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
+                description: Params will be passed into the loading process as environment
+                  variables.
+                type: object
+              resources:
+                description: Resources are the compute resources required by the container.
+                properties:
+                  cpu:
+                    default: 2
+                    description: CPU resources.
+                    format: int64
+                    type: integer
+                  disk:
+                    default: 10
+                    description: Disk size in Gigabytes.
+                    format: int64
+                    type: integer
+                  gpu:
+                    description: GPU resources.
+                    properties:
+                      count:
+                        description: Count is the number of GPUs.
+                        format: int64
+                        type: integer
+                      type:
+                        description: Type of GPU.
+                        type: string
+                    type: object
+                  memory:
+                    default: 10
+                    description: Memory is the amount of RAM in Gigabytes.
+                    format: int64
+                    type: integer
+                type: object
+            required:
+            - filename
+            - image
+            type: object
+          status:
+            description: Status is the observed state of the Dataset.
+            properties:
+              conditions:
+                description: Conditions is the list of conditions that describe the
+                  current state of the Dataset.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                default: false
+                description: Ready indicates that the Dataset is ready to use. See
+                  Conditions for more details.
+                type: boolean
+              upload:
+                description: Upload contains details the controller returns from a
+                  requested signed upload URL.
+                properties:
+                  md5checksum:
+                    description: Md5Checksum is the last md5 checksum that resulted
+                      in the successful creation of an UploadURL.
+                    maxLength: 32
+                    minLength: 32
+                    pattern: ^[a-fA-F0-9]{32}$
+                    type: string
+                  uploadURL:
+                    description: the Signed upload URL
+                    type: string
+                type: object
+              url:
+                description: URL of the loaded data.
+                type: string
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -240,236 +253,248 @@ spec:
   group: substratus.ai
   names:
     categories:
-      - ai
+    - ai
     kind: Model
     listKind: ModelList
     plural: models
     singular: model
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.ready
-          name: Ready
-          type: boolean
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description:
-            "The Model API is used to build and train machine learning models.
-            \n - Base models can be built from a Git repository. \n - Models can be
-            trained by combining a base Model with a Dataset. \n - Model artifacts are
-            persisted in cloud buckets."
-          properties:
-            apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-              type: string
-            kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec is the desired state of the Model.
-              properties:
-                baseModel:
-                  description:
-                    BaseModel should be set in order to mount another model
-                    to be used for transfer learning.
-                  properties:
-                    name:
-                      description: Name of Kubernetes object.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                command:
-                  description: Command to run in the container.
-                  items:
+  - additionalPrinterColumns:
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "The Model API is used to build and train machine learning models.
+          \n - Base models can be built from a Git repository. \n - Models can be
+          trained by combining a base Model with a Dataset. \n - Model artifacts are
+          persisted in cloud buckets."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the desired state of the Model.
+            properties:
+              baseModel:
+                description: BaseModel should be set in order to mount another model
+                  to be used for transfer learning.
+                properties:
+                  name:
+                    description: Name of Kubernetes object.
                     type: string
-                  type: array
-                image:
-                  description: Image that contains model code and dependencies.
-                  properties:
-                    git:
-                      description:
-                        Git is a reference to a git repository that will
-                        be built within the cluster. Built image will be set in the
-                        Image field.
-                      properties:
-                        branch:
-                          description: Branch is the git branch to use.
-                          type: string
-                        path:
-                          description:
-                            Path within the git repository referenced by
-                            url.
-                          type: string
-                        url:
-                          description: "URL to the git repository. Example: https://github.com/my-username/my-repo"
-                          type: string
-                      required:
-                        - url
-                      type: object
-                    name:
-                      description: 'Name of container image (example: "docker.io/your-username/your-image").'
-                      type: string
-                  type: object
-                params:
-                  additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    x-kubernetes-int-or-string: true
-                  description:
-                    Parameters are passing into the model training/loading
-                    container as environment variables. Environment variable name will
-                    be `"PARAM_" + uppercase(key)`.
-                  type: object
-                resources:
-                  description: Resources are the compute resources required by the container.
-                  properties:
-                    cpu:
-                      default: 2
-                      description: CPU resources.
-                      format: int64
-                      type: integer
-                    disk:
-                      default: 10
-                      description: Disk size in Gigabytes.
-                      format: int64
-                      type: integer
-                    gpu:
-                      description: GPU resources.
-                      properties:
-                        count:
-                          description: Count is the number of GPUs.
-                          format: int64
-                          type: integer
-                        type:
-                          description: Type of GPU.
-                          type: string
-                      type: object
-                    memory:
-                      default: 10
-                      description: Memory is the amount of RAM in Gigabytes.
-                      format: int64
-                      type: integer
-                  type: object
-                trainingDataset:
-                  description: Dataset to mount for training.
-                  properties:
-                    name:
-                      description: Name of Kubernetes object.
-                      type: string
-                  required:
-                    - name
-                  type: object
-              required:
-                - image
-              type: object
-            status:
-              description: Status is the observed state of the Model.
-              properties:
-                conditions:
-                  description:
-                    Conditions is the list of conditions that describe the
-                    current state of the Model.
-                  items:
-                    description:
-                      "Condition contains details for one aspect of the current
-                      state of this API Resource. --- This struct is intended for direct
-                      use as an array at the field path .status.conditions.  For example,
-                      \n type FooStatus struct{ // Represents the observations of a
-                      foo's current state. // Known .status.conditions.type are: \"Available\",
-                      \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                      // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                      `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                      protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                required:
+                - name
+                type: object
+              command:
+                description: Command to run in the container.
+                items:
+                  type: string
+                type: array
+              image:
+                description: Image that contains model code and dependencies.
+                properties:
+                  git:
+                    description: Git is a reference to a git repository that will
+                      be built within the cluster. Built image will be set in the
+                      Image field.
                     properties:
-                      lastTransitionTime:
-                        description:
-                          lastTransitionTime is the last time the condition
-                          transitioned from one status to another. This should be when
-                          the underlying condition changed.  If that is not known, then
-                          using the time when the API field changed is acceptable.
-                        format: date-time
+                      branch:
+                        description: Branch is the git branch to use.
                         type: string
-                      message:
-                        description:
-                          message is a human readable message indicating
-                          details about the transition. This may be an empty string.
-                        maxLength: 32768
+                      path:
+                        description: Path within the git repository referenced by
+                          url.
                         type: string
-                      observedGeneration:
-                        description:
-                          observedGeneration represents the .metadata.generation
-                          that the condition was set based upon. For instance, if .metadata.generation
-                          is currently 12, but the .status.conditions[x].observedGeneration
-                          is 9, the condition is out of date with respect to the current
-                          state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description:
-                          reason contains a programmatic identifier indicating
-                          the reason for the condition's last transition. Producers
-                          of specific condition types may define expected values and
-                          meanings for this field, and whether the values are considered
-                          a guaranteed API. The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description:
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          --- Many .condition.type values are consistent across resources
-                          like Available, but because arbitrary conditions can be useful
-                          (see .node.status.conditions), the ability to deconflict is
-                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      url:
+                        description: 'URL to the git repository. Example: https://github.com/my-username/my-repo'
                         type: string
                     required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                    - url
                     type: object
-                  type: array
-                ready:
-                  default: false
-                  description:
-                    Ready indicates that the Model is ready to use. See Conditions
-                    for more details.
-                  type: boolean
-                url:
-                  description: URL of model artifacts.
-                  type: string
-              required:
-                - ready
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                  name:
+                    description: 'Name of container image (example: "docker.io/your-username/your-image").'
+                    type: string
+                  upload:
+                    description: Upload is a signal that a local tar of the directory
+                      should be uploaded to be built as an image.
+                    properties:
+                      md5checksum:
+                        description: Md5Checksum is the md5 checksum of the tar'd
+                          repo root requested to be uploaded and built.
+                        maxLength: 32
+                        minLength: 32
+                        pattern: ^[a-fA-F0-9]{32}$
+                        type: string
+                    type: object
+                type: object
+              params:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
+                description: Parameters are passing into the model training/loading
+                  container as environment variables. Environment variable name will
+                  be `"PARAM_" + uppercase(key)`.
+                type: object
+              resources:
+                description: Resources are the compute resources required by the container.
+                properties:
+                  cpu:
+                    default: 2
+                    description: CPU resources.
+                    format: int64
+                    type: integer
+                  disk:
+                    default: 10
+                    description: Disk size in Gigabytes.
+                    format: int64
+                    type: integer
+                  gpu:
+                    description: GPU resources.
+                    properties:
+                      count:
+                        description: Count is the number of GPUs.
+                        format: int64
+                        type: integer
+                      type:
+                        description: Type of GPU.
+                        type: string
+                    type: object
+                  memory:
+                    default: 10
+                    description: Memory is the amount of RAM in Gigabytes.
+                    format: int64
+                    type: integer
+                type: object
+              trainingDataset:
+                description: Dataset to mount for training.
+                properties:
+                  name:
+                    description: Name of Kubernetes object.
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - image
+            type: object
+          status:
+            description: Status is the observed state of the Model.
+            properties:
+              conditions:
+                description: Conditions is the list of conditions that describe the
+                  current state of the Model.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                default: false
+                description: Ready indicates that the Model is ready to use. See Conditions
+                  for more details.
+                type: boolean
+              upload:
+                description: Upload contains details the controller returns from a
+                  requested signed upload URL.
+                properties:
+                  md5checksum:
+                    description: Md5Checksum is the last md5 checksum that resulted
+                      in the successful creation of an UploadURL.
+                    maxLength: 32
+                    minLength: 32
+                    pattern: ^[a-fA-F0-9]{32}$
+                    type: string
+                  uploadURL:
+                    description: the Signed upload URL
+                    type: string
+                type: object
+              url:
+                description: URL of model artifacts.
+                type: string
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -482,236 +507,248 @@ spec:
   group: substratus.ai
   names:
     categories:
-      - ai
+    - ai
     kind: Notebook
     listKind: NotebookList
     plural: notebooks
     singular: notebook
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.ready
-          name: Ready
-          type: boolean
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description:
-            "The Notebook API can be used to quickly spin up a development
-            environment backed by high performance compute. \n - Notebooks integrate
-            with the Model and Dataset APIs allow for quick iteration. \n - Notebooks
-            can be synced to local directories to streamline developer experiences using
-            Substratus kubectl plugins."
-          properties:
-            apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-              type: string
-            kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec is the observed state of the Notebook.
-              properties:
-                command:
-                  description: Command to run in the container.
-                  items:
+  - additionalPrinterColumns:
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: "The Notebook API can be used to quickly spin up a development
+          environment backed by high performance compute. \n - Notebooks integrate
+          with the Model and Dataset APIs allow for quick iteration. \n - Notebooks
+          can be synced to local directories to streamline developer experiences using
+          Substratus kubectl plugins."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the observed state of the Notebook.
+            properties:
+              command:
+                description: Command to run in the container.
+                items:
+                  type: string
+                type: array
+              dataset:
+                description: Dataset to load into the notebook container.
+                properties:
+                  name:
+                    description: Name of Kubernetes object.
                     type: string
-                  type: array
-                dataset:
-                  description: Dataset to load into the notebook container.
-                  properties:
-                    name:
-                      description: Name of Kubernetes object.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                image:
-                  description: Image that contains notebook and dependencies.
-                  properties:
-                    git:
-                      description:
-                        Git is a reference to a git repository that will
-                        be built within the cluster. Built image will be set in the
-                        Image field.
-                      properties:
-                        branch:
-                          description: Branch is the git branch to use.
-                          type: string
-                        path:
-                          description:
-                            Path within the git repository referenced by
-                            url.
-                          type: string
-                        url:
-                          description: "URL to the git repository. Example: https://github.com/my-username/my-repo"
-                          type: string
-                      required:
-                        - url
-                      type: object
-                    name:
-                      description: 'Name of container image (example: "docker.io/your-username/your-image").'
-                      type: string
-                  type: object
-                model:
-                  description: Model to load into the notebook container.
-                  properties:
-                    name:
-                      description: Name of Kubernetes object.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                params:
-                  additionalProperties:
-                    anyOf:
-                      - type: integer
-                      - type: string
-                    x-kubernetes-int-or-string: true
-                  description:
-                    Params will be passed into the notebook container as
-                    environment variables.
-                  type: object
-                resources:
-                  description: Resources are the compute resources required by the container.
-                  properties:
-                    cpu:
-                      default: 2
-                      description: CPU resources.
-                      format: int64
-                      type: integer
-                    disk:
-                      default: 10
-                      description: Disk size in Gigabytes.
-                      format: int64
-                      type: integer
-                    gpu:
-                      description: GPU resources.
-                      properties:
-                        count:
-                          description: Count is the number of GPUs.
-                          format: int64
-                          type: integer
-                        type:
-                          description: Type of GPU.
-                          type: string
-                      type: object
-                    memory:
-                      default: 10
-                      description: Memory is the amount of RAM in Gigabytes.
-                      format: int64
-                      type: integer
-                  type: object
-                suspend:
-                  description:
-                    Suspend should be set to true to stop the notebook (Pod)
-                    from running.
-                  type: boolean
-              required:
-                - image
-              type: object
-            status:
-              description: Status is the observed state of the Notebook.
-              properties:
-                conditions:
-                  description:
-                    Conditions is the list of conditions that describe the
-                    current state of the Notebook.
-                  items:
-                    description:
-                      "Condition contains details for one aspect of the current
-                      state of this API Resource. --- This struct is intended for direct
-                      use as an array at the field path .status.conditions.  For example,
-                      \n type FooStatus struct{ // Represents the observations of a
-                      foo's current state. // Known .status.conditions.type are: \"Available\",
-                      \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                      // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                      `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                      protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                required:
+                - name
+                type: object
+              image:
+                description: Image that contains notebook and dependencies.
+                properties:
+                  git:
+                    description: Git is a reference to a git repository that will
+                      be built within the cluster. Built image will be set in the
+                      Image field.
                     properties:
-                      lastTransitionTime:
-                        description:
-                          lastTransitionTime is the last time the condition
-                          transitioned from one status to another. This should be when
-                          the underlying condition changed.  If that is not known, then
-                          using the time when the API field changed is acceptable.
-                        format: date-time
+                      branch:
+                        description: Branch is the git branch to use.
                         type: string
-                      message:
-                        description:
-                          message is a human readable message indicating
-                          details about the transition. This may be an empty string.
-                        maxLength: 32768
+                      path:
+                        description: Path within the git repository referenced by
+                          url.
                         type: string
-                      observedGeneration:
-                        description:
-                          observedGeneration represents the .metadata.generation
-                          that the condition was set based upon. For instance, if .metadata.generation
-                          is currently 12, but the .status.conditions[x].observedGeneration
-                          is 9, the condition is out of date with respect to the current
-                          state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description:
-                          reason contains a programmatic identifier indicating
-                          the reason for the condition's last transition. Producers
-                          of specific condition types may define expected values and
-                          meanings for this field, and whether the values are considered
-                          a guaranteed API. The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description:
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          --- Many .condition.type values are consistent across resources
-                          like Available, but because arbitrary conditions can be useful
-                          (see .node.status.conditions), the ability to deconflict is
-                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      url:
+                        description: 'URL to the git repository. Example: https://github.com/my-username/my-repo'
                         type: string
                     required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                    - url
                     type: object
-                  type: array
-                ready:
-                  default: false
-                  description:
-                    Ready indicates that the Notebook is ready to serve.
-                    See Conditions for more details.
-                  type: boolean
-              required:
-                - ready
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                  name:
+                    description: 'Name of container image (example: "docker.io/your-username/your-image").'
+                    type: string
+                  upload:
+                    description: Upload is a signal that a local tar of the directory
+                      should be uploaded to be built as an image.
+                    properties:
+                      md5checksum:
+                        description: Md5Checksum is the md5 checksum of the tar'd
+                          repo root requested to be uploaded and built.
+                        maxLength: 32
+                        minLength: 32
+                        pattern: ^[a-fA-F0-9]{32}$
+                        type: string
+                    type: object
+                type: object
+              model:
+                description: Model to load into the notebook container.
+                properties:
+                  name:
+                    description: Name of Kubernetes object.
+                    type: string
+                required:
+                - name
+                type: object
+              params:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
+                description: Params will be passed into the notebook container as
+                  environment variables.
+                type: object
+              resources:
+                description: Resources are the compute resources required by the container.
+                properties:
+                  cpu:
+                    default: 2
+                    description: CPU resources.
+                    format: int64
+                    type: integer
+                  disk:
+                    default: 10
+                    description: Disk size in Gigabytes.
+                    format: int64
+                    type: integer
+                  gpu:
+                    description: GPU resources.
+                    properties:
+                      count:
+                        description: Count is the number of GPUs.
+                        format: int64
+                        type: integer
+                      type:
+                        description: Type of GPU.
+                        type: string
+                    type: object
+                  memory:
+                    default: 10
+                    description: Memory is the amount of RAM in Gigabytes.
+                    format: int64
+                    type: integer
+                type: object
+              suspend:
+                description: Suspend should be set to true to stop the notebook (Pod)
+                  from running.
+                type: boolean
+            required:
+            - image
+            type: object
+          status:
+            description: Status is the observed state of the Notebook.
+            properties:
+              conditions:
+                description: Conditions is the list of conditions that describe the
+                  current state of the Notebook.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                default: false
+                description: Ready indicates that the Notebook is ready to serve.
+                  See Conditions for more details.
+                type: boolean
+              upload:
+                description: Upload contains details the controller returns from a
+                  requested signed upload URL.
+                properties:
+                  md5checksum:
+                    description: Md5Checksum is the last md5 checksum that resulted
+                      in the successful creation of an UploadURL.
+                    maxLength: 32
+                    minLength: 32
+                    pattern: ^[a-fA-F0-9]{32}$
+                    type: string
+                  uploadURL:
+                    description: the Signed upload URL
+                    type: string
+                type: object
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -724,209 +761,223 @@ spec:
   group: substratus.ai
   names:
     categories:
-      - ai
+    - ai
     kind: Server
     listKind: ServerList
     plural: servers
     singular: server
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.ready
-          name: Ready
-          type: boolean
-      name: v1
-      schema:
-        openAPIV3Schema:
-          description:
-            The Server API is used to deploy a server that exposes the capabilities
-            of a Model via a HTTP interface.
-          properties:
-            apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
-              type: string
-            kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec is the desired state of the Server.
-              properties:
-                command:
-                  description: Command to run in the container.
-                  items:
-                    type: string
-                  type: array
-                image:
-                  description: Image that contains model serving application and dependencies.
-                  properties:
-                    git:
-                      description:
-                        Git is a reference to a git repository that will
-                        be built within the cluster. Built image will be set in the
-                        Image field.
-                      properties:
-                        branch:
-                          description: Branch is the git branch to use.
-                          type: string
-                        path:
-                          description:
-                            Path within the git repository referenced by
-                            url.
-                          type: string
-                        url:
-                          description: "URL to the git repository. Example: https://github.com/my-username/my-repo"
-                          type: string
-                      required:
-                        - url
-                      type: object
-                    name:
-                      description: 'Name of container image (example: "docker.io/your-username/your-image").'
-                      type: string
-                  type: object
-                model:
-                  description: Model references the Model object to be served.
-                  properties:
-                    name:
-                      description: Name of Kubernetes object.
-                      type: string
-                  required:
-                    - name
-                  type: object
-                resources:
-                  description: Resources are the compute resources required by the container.
-                  properties:
-                    cpu:
-                      default: 2
-                      description: CPU resources.
-                      format: int64
-                      type: integer
-                    disk:
-                      default: 10
-                      description: Disk size in Gigabytes.
-                      format: int64
-                      type: integer
-                    gpu:
-                      description: GPU resources.
-                      properties:
-                        count:
-                          description: Count is the number of GPUs.
-                          format: int64
-                          type: integer
-                        type:
-                          description: Type of GPU.
-                          type: string
-                      type: object
-                    memory:
-                      default: 10
-                      description: Memory is the amount of RAM in Gigabytes.
-                      format: int64
-                      type: integer
-                  type: object
-              required:
-                - image
-              type: object
-            status:
-              description: Status is the observed state of the Server.
-              properties:
-                conditions:
-                  description:
-                    Conditions is the list of conditions that describe the
-                    current state of the Server.
-                  items:
-                    description:
-                      "Condition contains details for one aspect of the current
-                      state of this API Resource. --- This struct is intended for direct
-                      use as an array at the field path .status.conditions.  For example,
-                      \n type FooStatus struct{ // Represents the observations of a
-                      foo's current state. // Known .status.conditions.type are: \"Available\",
-                      \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                      // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                      `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                      protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+  - additionalPrinterColumns:
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: The Server API is used to deploy a server that exposes the capabilities
+          of a Model via a HTTP interface.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the desired state of the Server.
+            properties:
+              command:
+                description: Command to run in the container.
+                items:
+                  type: string
+                type: array
+              image:
+                description: Image that contains model serving application and dependencies.
+                properties:
+                  git:
+                    description: Git is a reference to a git repository that will
+                      be built within the cluster. Built image will be set in the
+                      Image field.
                     properties:
-                      lastTransitionTime:
-                        description:
-                          lastTransitionTime is the last time the condition
-                          transitioned from one status to another. This should be when
-                          the underlying condition changed.  If that is not known, then
-                          using the time when the API field changed is acceptable.
-                        format: date-time
+                      branch:
+                        description: Branch is the git branch to use.
                         type: string
-                      message:
-                        description:
-                          message is a human readable message indicating
-                          details about the transition. This may be an empty string.
-                        maxLength: 32768
+                      path:
+                        description: Path within the git repository referenced by
+                          url.
                         type: string
-                      observedGeneration:
-                        description:
-                          observedGeneration represents the .metadata.generation
-                          that the condition was set based upon. For instance, if .metadata.generation
-                          is currently 12, but the .status.conditions[x].observedGeneration
-                          is 9, the condition is out of date with respect to the current
-                          state of the instance.
-                        format: int64
-                        minimum: 0
-                        type: integer
-                      reason:
-                        description:
-                          reason contains a programmatic identifier indicating
-                          the reason for the condition's last transition. Producers
-                          of specific condition types may define expected values and
-                          meanings for this field, and whether the values are considered
-                          a guaranteed API. The value should be a CamelCase string.
-                          This field may not be empty.
-                        maxLength: 1024
-                        minLength: 1
-                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description:
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          --- Many .condition.type values are consistent across resources
-                          like Available, but because arbitrary conditions can be useful
-                          (see .node.status.conditions), the ability to deconflict is
-                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      url:
+                        description: 'URL to the git repository. Example: https://github.com/my-username/my-repo'
                         type: string
                     required:
-                      - lastTransitionTime
-                      - message
-                      - reason
-                      - status
-                      - type
+                    - url
                     type: object
-                  type: array
-                ready:
-                  default: false
-                  description:
-                    Ready indicates whether the Server is ready to serve
-                    traffic. See Conditions for more details.
-                  type: boolean
-              required:
-                - ready
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                  name:
+                    description: 'Name of container image (example: "docker.io/your-username/your-image").'
+                    type: string
+                  upload:
+                    description: Upload is a signal that a local tar of the directory
+                      should be uploaded to be built as an image.
+                    properties:
+                      md5checksum:
+                        description: Md5Checksum is the md5 checksum of the tar'd
+                          repo root requested to be uploaded and built.
+                        maxLength: 32
+                        minLength: 32
+                        pattern: ^[a-fA-F0-9]{32}$
+                        type: string
+                    type: object
+                type: object
+              model:
+                description: Model references the Model object to be served.
+                properties:
+                  name:
+                    description: Name of Kubernetes object.
+                    type: string
+                required:
+                - name
+                type: object
+              resources:
+                description: Resources are the compute resources required by the container.
+                properties:
+                  cpu:
+                    default: 2
+                    description: CPU resources.
+                    format: int64
+                    type: integer
+                  disk:
+                    default: 10
+                    description: Disk size in Gigabytes.
+                    format: int64
+                    type: integer
+                  gpu:
+                    description: GPU resources.
+                    properties:
+                      count:
+                        description: Count is the number of GPUs.
+                        format: int64
+                        type: integer
+                      type:
+                        description: Type of GPU.
+                        type: string
+                    type: object
+                  memory:
+                    default: 10
+                    description: Memory is the amount of RAM in Gigabytes.
+                    format: int64
+                    type: integer
+                type: object
+            required:
+            - image
+            type: object
+          status:
+            description: Status is the observed state of the Server.
+            properties:
+              conditions:
+                description: Conditions is the list of conditions that describe the
+                  current state of the Server.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                default: false
+                description: Ready indicates whether the Server is ready to serve
+                  traffic. See Conditions for more details.
+                type: boolean
+              upload:
+                description: Upload contains details the controller returns from a
+                  requested signed upload URL.
+                properties:
+                  md5checksum:
+                    description: Md5Checksum is the last md5 checksum that resulted
+                      in the successful creation of an UploadURL.
+                    maxLength: 32
+                    minLength: 32
+                    pattern: ^[a-fA-F0-9]{32}$
+                    type: string
+                  uploadURL:
+                    description: the Signed upload URL
+                    type: string
+                type: object
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -954,37 +1005,37 @@ metadata:
   name: leader-election-role
   namespace: substratus
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -992,170 +1043,170 @@ metadata:
   creationTimestamp: null
   name: manager-role
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - serviceaccounts
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - services
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - datasets
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - datasets/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - datasets/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - models
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - models/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - models/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - notebooks
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - notebooks/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - notebooks/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - servers
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - servers/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - substratus.ai
-    resources:
-      - servers/status
-    verbs:
-      - get
-      - patch
-      - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - substratus.ai
+  resources:
+  - datasets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - substratus.ai
+  resources:
+  - datasets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - substratus.ai
+  resources:
+  - datasets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - substratus.ai
+  resources:
+  - models
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - substratus.ai
+  resources:
+  - models/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - substratus.ai
+  resources:
+  - models/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - substratus.ai
+  resources:
+  - notebooks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - substratus.ai
+  resources:
+  - notebooks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - substratus.ai
+  resources:
+  - notebooks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - substratus.ai
+  resources:
+  - servers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - substratus.ai
+  resources:
+  - servers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - substratus.ai
+  resources:
+  - servers/status
+  verbs:
+  - get
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1169,10 +1220,10 @@ metadata:
     app.kubernetes.io/part-of: substratus
   name: metrics-reader
 rules:
-  - nonResourceURLs:
-      - /metrics
-    verbs:
-      - get
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -1186,18 +1237,18 @@ metadata:
     app.kubernetes.io/part-of: substratus
   name: proxy-role
 rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -1216,9 +1267,9 @@ roleRef:
   kind: Role
   name: leader-election-role
 subjects:
-  - kind: ServiceAccount
-    name: controller-manager
-    namespace: substratus
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: substratus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1236,9 +1287,9 @@ roleRef:
   kind: ClusterRole
   name: manager-role
 subjects:
-  - kind: ServiceAccount
-    name: controller-manager
-    namespace: substratus
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: substratus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1256,9 +1307,9 @@ roleRef:
   kind: ClusterRole
   name: proxy-role
 subjects:
-  - kind: ServiceAccount
-    name: controller-manager
-    namespace: substratus
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: substratus
 ---
 apiVersion: v1
 kind: Service
@@ -1275,10 +1326,10 @@ metadata:
   namespace: substratus
 spec:
   ports:
-    - name: https
-      port: 8443
-      protocol: TCP
-      targetPort: https
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
   selector:
     control-plane: controller-manager
 ---
@@ -1311,77 +1362,77 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - arm64
-                      - ppc64le
-                      - s390x
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - linux
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+                - ppc64le
+                - s390x
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
       containers:
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:8080/
-            - --logtostderr=true
-            - --v=0
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-              protocol: TCP
-          resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-        - args:
-            - --health-probe-bind-address=:8081
-            - --metrics-bind-address=127.0.0.1:8080
-            - --leader-elect
-          command:
-            - /manager
-          envFrom:
-            - configMapRef:
-                name: system
-          image: docker.io/substratusai/controller-manager:v0.4.1-alpha
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8081
-            initialDelaySeconds: 15
-            periodSeconds: 20
-          name: manager
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: 8081
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 10m
-              memory: 64Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        envFrom:
+        - configMapRef:
+            name: system
+        image: docker.io/substratusai/controller-manager:v0.4.2-alpha
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager


### PR DESCRIPTION
Currently v0.4.0 gets installed which results in following error message:
```
"ModelServer: no matches for kind \"ModelServer\" in version \"substratus.ai/v1\""
```

This patch bumps version to v0.4.2-alpha instead which I validated is working.

I also had to pin image loader to v0.1.1 because the controller in v0.4.2 doesn't use /content directory yet, however the latest published images was saving the model to /content/model

Also ran `make install/kubernetes/system.yaml`