### PR TITLE
adding more target platforms to the docker build and push of services and the installer

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: "linux/amd64"
+          platforms: "linux/amd64,linux/arm64"
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-controller-manager.outputs.tags }}
           labels: ${{ steps.meta-controller-manager.outputs.labels }}
@@ -47,7 +47,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.gcpmanager
-          platforms: "linux/amd64"
+          platforms: "linux/amd64,linux/arm64"
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-gcp-manager.outputs.tags }}
           labels: ${{ steps.meta-gcp-manager.outputs.labels }}
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: install/
-          platforms: "linux/amd64"
+          platforms: "linux/amd64,linux/arm64"
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-installer.outputs.tags }}
           labels: ${{ steps.meta-installer.outputs.labels }}


### PR DESCRIPTION
## What is this change?

Adds more platforms to our dockerhub images.

## Why make this change?

I'm working through testing of our quickstart and unable to do it locally because we don't publish an installer image that works on darwin/arm.

https://github.com/substratusai/substratusai.github.io/pull/25/files#diff-a0c51efce13035f3226d49c4ce58c615c59865c9a987b210b3698d539880e9bdR35