### PR TITLE
set save_steps to 5 by default

### DIFF
--- a/examples/falcon-7b-instruct/finetuned-model-custom-prompt.yaml
+++ b/examples/falcon-7b-instruct/finetuned-model-custom-prompt.yaml
@@ -11,7 +11,7 @@ spec:
     name: k8s-instructions
   params:
     num_train_epochs: 1
-    # Save to checkpoint every 5 steps
+    # Save to checkpoint every 5 steps for a dataset with ~70 steps total.
     save_steps: 5
     prompt_template: |
       You're a helpful assistant that helps with generating K8s YAML manifests. Your responses should only be YAML or multi YAML files

--- a/examples/falcon-7b-instruct/finetuned-model-custom-prompt.yaml
+++ b/examples/falcon-7b-instruct/finetuned-model-custom-prompt.yaml
@@ -11,6 +11,8 @@ spec:
     name: k8s-instructions
   params:
     num_train_epochs: 1
+    # Save to checkpoint every 5 steps
+    save_steps: 5
     prompt_template: |
       You're a helpful assistant that helps with generating K8s YAML manifests. Your responses should only be YAML or multi YAML files
       ## Instruction

--- a/examples/falcon-7b-instruct/finetuned-model.yaml
+++ b/examples/falcon-7b-instruct/finetuned-model.yaml
@@ -13,6 +13,8 @@ spec:
     # See HuggingFace transformers.TrainingArguments for all parameters
     # https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments
     num_train_epochs: 1
+    # save to checkpoint every 5 steps
+    save_steps: 5
   resources:
     gpu:
       count: 4

--- a/examples/falcon-7b-instruct/finetuned-model.yaml
+++ b/examples/falcon-7b-instruct/finetuned-model.yaml
@@ -13,7 +13,7 @@ spec:
     # See HuggingFace transformers.TrainingArguments for all parameters
     # https://huggingface.co/docs/transformers/main_classes/trainer#transformers.TrainingArguments
     num_train_epochs: 1
-    # save to checkpoint every 5 steps
+    # Save to checkpoint every 5 steps for a dataset with ~70 steps total
     save_steps: 5
   resources:
     gpu:


### PR DESCRIPTION
The HuggingFace transformer.TrainingArguments uses a default value of 500, however that doesn't make sense for our k8s dataset which only uses 71 steps. So we should set a smaller save_steps value in our examples.

This also helps with users understanding how to override specific parameters.