### PR TITLE
make attach-gpu configurable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ VERSION ?= v0.8.0
 IMG ?= docker.io/substratusai/controller-manager:${VERSION}
 IMG_GCPMANAGER ?= docker.io/substratusai/gcp-manager:${VERSION}
 
+# Set to false if you don't want GPU nodepools created
+ATTACH_GPU_NODEPOOLS=true
+
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26.1
 
@@ -123,7 +127,7 @@ dev-up:
 	  -v ${HOME}/.kube:/root/.kube \
 	  -e PROJECT=$(shell gcloud config get project) \
 	  -e TOKEN=$(shell gcloud auth print-access-token) \
-	  -e TF_VAR_attach_gpu_nodepools=false \
+	  -e TF_VAR_attach_gpu_nodepools=${ATTACH_GPU_NODEPOOLS} \
 	  -e INSTALL_OPERATOR=false \
 	  substratus-installer gcp-up.sh
 	mkdir -p secrets
@@ -135,7 +139,7 @@ dev-down:
 	  -v ${HOME}/.kube:/root/.kube \
 	  -e PROJECT=$(shell gcloud config get project) \
 	  -e TOKEN=$(shell gcloud auth print-access-token) \
-	  -e TF_VAR_attach_gpu_nodepools=false \
+	  -e TF_VAR_attach_gpu_nodepools=${ATTACH_GPU_NODEPOOLS} \
 	  substratus-installer gcp-down.sh
 	rm ./secrets/gcp-manager-key.json
 

--- a/examples/falcon-7b-instruct/finetuned-model.yaml
+++ b/examples/falcon-7b-instruct/finetuned-model.yaml
@@ -16,5 +16,5 @@ spec:
     save_steps: 5
   resources:
     gpu:
-      count: 1
-      type: nvidia-a100
+      count: 4
+      type: nvidia-l4

--- a/install/terraform/gcp/cluster_node_pools_gpu_a100.tf
+++ b/install/terraform/gcp/cluster_node_pools_gpu_a100.tf
@@ -71,7 +71,7 @@ resource "google_container_node_pool" "a2-highgpu-2g" {
     spot         = true
     machine_type = "a2-highgpu-2g"
     ephemeral_storage_local_ssd_config {
-      local_ssd_count = 1
+      local_ssd_count = 4
     }
     gcfs_config {
       enabled = true
@@ -106,7 +106,7 @@ resource "google_container_node_pool" "a2-highgpu-4g" {
     spot         = true
     machine_type = "a2-highgpu-4g"
     ephemeral_storage_local_ssd_config {
-      local_ssd_count = 1
+      local_ssd_count = 4
     }
     gcfs_config {
       enabled = true
@@ -141,7 +141,7 @@ resource "google_container_node_pool" "a2-highgpu-8g" {
     spot         = true
     machine_type = "a2-highgpu-8g"
     ephemeral_storage_local_ssd_config {
-      local_ssd_count = 1
+      local_ssd_count = 8
     }
     gcfs_config {
       enabled = true


### PR DESCRIPTION
* Changes Makefile to create GPU nodepools by default and allow overriding
* Fix A100 GPU nodepools local SSD count (this was resulting in errors before)
* switch back falcon to use L4 GPU