### PR TITLE
Fix the flaky `TestModelTrainerFromGit`and `TestModelLoaderFromGit` tests

### DIFF
--- a/internal/controller/main_test.go
+++ b/internal/controller/main_test.go
@@ -212,7 +212,7 @@ func testContainerBuild(t *testing.T, obj testObject, kind string) {
 		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, obj)
 		assert.NoError(t, err, "getting object")
 		assert.True(t, meta.IsStatusConditionTrue(*obj.GetConditions(), apiv1.ConditionBuilt))
-	}, timeout*2, interval, "waiting for the container to be ready")
+	}, timeout*4, interval, "waiting for the container to be ready")
 }
 
 func testParamsConfigMap(t *testing.T, obj testObject, kind string, content string) {

--- a/internal/controller/main_test.go
+++ b/internal/controller/main_test.go
@@ -212,7 +212,7 @@ func testContainerBuild(t *testing.T, obj testObject, kind string) {
 		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, obj)
 		assert.NoError(t, err, "getting object")
 		assert.True(t, meta.IsStatusConditionTrue(*obj.GetConditions(), apiv1.ConditionBuilt))
-	}, timeout, interval, "waiting for the container to be ready")
+	}, timeout*2, interval, "waiting for the container to be ready")
 }
 
 func testParamsConfigMap(t *testing.T, obj testObject, kind string, content string) {


### PR DESCRIPTION
## What is this change?

This change adds some retry logic to a test that seems to fail in github actions regularly (though never locally). This may take a few iterations since I can't repro on my workstation.

## Why make this change?

We are regularly seeing this test fail because the models don't reconcile quickly enough. I dont think this is a problem we've seen happen in the wild so I think this is more of a test issue than an actual problem with the reconciler. The error:

```
the object has been modified; please apply your changes to the latest version and try again
```

Recent failures:
https://github.com/substratusai/substratus/actions/runs/5826988660/job/15802093114
https://github.com/substratusai/substratus/actions/runs/5827031817/job/15802216794