### PR TITLE
reconcile service account call SCI

### DIFF
--- a/cmd/controllermanager/main.go
+++ b/cmd/controllermanager/main.go
@@ -114,12 +114,13 @@ func main() {
 	}
 	defer conn.Close()
 	// Create a client using the connection
-	gc := sci.NewControllerClient(conn)
+	sciClient := sci.NewControllerClient(conn)
 
 	if err = (&controller.ModelReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		Cloud:  cld,
+		SCI:    sciClient,
 		ParamsReconciler: &controller.ParamsReconciler{
 			Scheme: mgr.GetScheme(),
 			Client: mgr.GetClient(),
@@ -132,7 +133,7 @@ func main() {
 		Scheme:    mgr.GetScheme(),
 		Client:    mgr.GetClient(),
 		Cloud:     cld,
-		SCI:       gc,
+		SCI:       sciClient,
 		NewObject: func() controller.BuildableObject { return &apiv1.Model{} },
 		Kind:      "Model",
 	}).SetupWithManager(mgr); err != nil {
@@ -143,6 +144,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		Cloud:  cld,
+		SCI:    sciClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Server")
 		os.Exit(1)
@@ -151,7 +153,7 @@ func main() {
 		Scheme:    mgr.GetScheme(),
 		Client:    mgr.GetClient(),
 		Cloud:     cld,
-		SCI:       gc,
+		SCI:       sciClient,
 		NewObject: func() controller.BuildableObject { return &apiv1.Server{} },
 		Kind:      "Server",
 	}).SetupWithManager(mgr); err != nil {
@@ -162,6 +164,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		Cloud:  cld,
+		SCI:    sciClient,
 		ParamsReconciler: &controller.ParamsReconciler{
 			Scheme: mgr.GetScheme(),
 			Client: mgr.GetClient(),
@@ -174,7 +177,7 @@ func main() {
 		Scheme:    mgr.GetScheme(),
 		Client:    mgr.GetClient(),
 		Cloud:     cld,
-		SCI:       gc,
+		SCI:       sciClient,
 		NewObject: func() controller.BuildableObject { return &apiv1.Notebook{} },
 		Kind:      "Notebook",
 	}).SetupWithManager(mgr); err != nil {
@@ -185,6 +188,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		Cloud:  cld,
+		SCI:    sciClient,
 		ParamsReconciler: &controller.ParamsReconciler{
 			Scheme: mgr.GetScheme(),
 			Client: mgr.GetClient(),
@@ -197,7 +201,7 @@ func main() {
 		Scheme:    mgr.GetScheme(),
 		Client:    mgr.GetClient(),
 		Cloud:     cld,
-		SCI:       gc,
+		SCI:       sciClient,
 		NewObject: func() controller.BuildableObject { return &apiv1.Dataset{} },
 		Kind:      "Dataset",
 	}).SetupWithManager(mgr); err != nil {

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -35,8 +35,9 @@ type Cloud interface {
 	AssociatePrincipal(*corev1.ServiceAccount)
 
 	// GetPrincipal returns the IAM Principal (GCP SA, AWS IAM Role) that should be used
-	// for a specific K8s Service Account
-	GetPrincipal(*corev1.ServiceAccount) string
+	// for a specific K8s Service Account. Returns the principal and whether the principal
+	// was already bound successfully to the service account.
+	GetPrincipal(*corev1.ServiceAccount) (string, bool)
 
 	// MountBucket mutates the given Pod metadata and Pod spec in order to append
 	// volumes mounts for a bucket.

--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -30,9 +30,13 @@ type Cloud interface {
 	// ObjectArtifactURL returns the URL of the artifact that was stored for a given Object.
 	ObjectArtifactURL(Object) *BucketURL
 
-	// AssociateServiceAccount associates the given service account with a cloud
-	// identity (i.e. updates annotations).
-	AssociateServiceAccount(*corev1.ServiceAccount)
+	// AssociatePrincipal associates the given K8s service account with a cloud
+	// identity (i.e. updates cloud specific annotations on K8s SA)
+	AssociatePrincipal(*corev1.ServiceAccount)
+
+	// GetPrincipal returns the IAM Principal (GCP SA, AWS IAM Role) that should be used
+	// for a specific K8s Service Account
+	GetPrincipal(*corev1.ServiceAccount) string
 
 	// MountBucket mutates the given Pod metadata and Pod spec in order to append
 	// volumes mounts for a bucket.

--- a/internal/cloud/common.go
+++ b/internal/cloud/common.go
@@ -6,12 +6,15 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 type Common struct {
 	ClusterName       string     `env:"CLUSTER_NAME" validate:"required"`
 	ArtifactBucketURL *BucketURL `env:"ARTIFACT_BUCKET_URL,noinit" validate:"required"`
 	RegistryURL       string     `env:"REGISTRY_URL" validate:"required"`
+	Principal         string     `env:"PRINCIPAL"`
 }
 
 func (c *Common) ObjectBuiltImageURL(obj BuildableObject) string {
@@ -45,6 +48,11 @@ func (c *Common) ObjectArtifactURL(obj Object) *BucketURL {
 	u := *c.ArtifactBucketURL
 	u.Path = filepath.Join(u.Path, objectHash(c.ClusterName, obj))
 	return &u
+}
+
+func (c *Common) GetPrincipal(sa *corev1.ServiceAccount) string {
+	// In future will need a way to associate a Principal for each service account
+	return c.Principal
 }
 
 func objectHash(cluster string, obj Object) string {

--- a/internal/cloud/common.go
+++ b/internal/cloud/common.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
-
-	corev1 "k8s.io/api/core/v1"
 )
 
 type Common struct {
@@ -48,11 +46,6 @@ func (c *Common) ObjectArtifactURL(obj Object) *BucketURL {
 	u := *c.ArtifactBucketURL
 	u.Path = filepath.Join(u.Path, objectHash(c.ClusterName, obj))
 	return &u
-}
-
-func (c *Common) GetPrincipal(sa *corev1.ServiceAccount) string {
-	// In future will need a way to associate a Principal for each service account
-	return c.Principal
 }
 
 func objectHash(cluster string, obj Object) string {

--- a/internal/cloud/common.go
+++ b/internal/cloud/common.go
@@ -12,7 +12,7 @@ type Common struct {
 	ClusterName       string     `env:"CLUSTER_NAME" validate:"required"`
 	ArtifactBucketURL *BucketURL `env:"ARTIFACT_BUCKET_URL,noinit" validate:"required"`
 	RegistryURL       string     `env:"REGISTRY_URL" validate:"required"`
-	Principal         string     `env:"PRINCIPAL"`
+	Principal         string     `env:"PRINCIPAL" validate:"required"`
 }
 
 func (c *Common) ObjectBuiltImageURL(obj BuildableObject) string {

--- a/internal/cloud/common_test.go
+++ b/internal/cloud/common_test.go
@@ -18,6 +18,7 @@ func TestCommon(t *testing.T) {
 	os.Setenv("CLUSTER_NAME", "my-cluster")
 	os.Setenv("ARTIFACT_BUCKET_URL", "gs://my-artifact-bucket")
 	os.Setenv("REGISTRY_URL", "gcr.io/my-project")
+	os.Setenv("PRINCIPAL", "dummy-value")
 
 	require.Error(t, validator.New().Struct(&common))
 	require.NoError(t, envconfig.Process(context.Background(), &common))
@@ -27,6 +28,7 @@ func TestCommon(t *testing.T) {
 		ClusterName:       "my-cluster",
 		ArtifactBucketURL: &cloud.BucketURL{Scheme: "gs", Bucket: "my-artifact-bucket"},
 		RegistryURL:       "gcr.io/my-project",
+		Principal:         "dummy-value",
 	}, common)
 
 	require.Equal(t, "gcr.io/my-project/my-cluster-model-my-ns-my-model:latest", common.ObjectBuiltImageURL(&apiv1.Model{

--- a/internal/cloud/gcp.go
+++ b/internal/cloud/gcp.go
@@ -60,6 +60,10 @@ func (gcp *GCP) AutoConfigure(ctx context.Context) error {
 		}
 	}
 
+	if gcp.Principal != "" {
+		gcp.Principal = fmt.Sprintf("substratus@%s.iam.gserviceaccount.com", gcp.ProjectID)
+	}
+
 	return nil
 }
 
@@ -114,10 +118,6 @@ func (gcp *GCP) MountBucket(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodS
 	}
 
 	return fmt.Errorf("container not found: %s", req.Container)
-}
-
-func (gcp *GCP) GetPrincipal(sa *corev1.ServiceAccount) string {
-	return fmt.Sprintf("substratus@%s.iam.gserviceaccount.com", gcp.ProjectID)
 }
 
 func (gcp *GCP) AssociatePrincipal(sa *corev1.ServiceAccount) {

--- a/internal/cloud/gcp.go
+++ b/internal/cloud/gcp.go
@@ -132,6 +132,9 @@ func (gcp *GCP) GetPrincipal(sa *corev1.ServiceAccount) (string, bool) {
 }
 
 func (gcp *GCP) AssociatePrincipal(sa *corev1.ServiceAccount) {
+	if sa.Annotations == nil {
+		sa.Annotations = map[string]string{}
+	}
 	principal, _ := gcp.GetPrincipal(sa)
 	sa.Annotations[GCPWorkloadIdentityLabel] = principal
 }

--- a/internal/cloud/gcp.go
+++ b/internal/cloud/gcp.go
@@ -116,11 +116,12 @@ func (gcp *GCP) MountBucket(podMetadata *metav1.ObjectMeta, podSpec *corev1.PodS
 	return fmt.Errorf("container not found: %s", req.Container)
 }
 
-func (gcp *GCP) AssociateServiceAccount(sa *corev1.ServiceAccount) {
-	if sa.Annotations == nil {
-		sa.Annotations = map[string]string{}
-	}
-	sa.Annotations["iam.gke.io/gcp-service-account"] = fmt.Sprintf("substratus-%s@%s.iam.gserviceaccount.com", sa.Name, gcp.ProjectID)
+func (gcp *GCP) GetPrincipal(sa *corev1.ServiceAccount) string {
+	return fmt.Sprintf("substratus@%s.iam.gserviceaccount.com", gcp.ProjectID)
+}
+
+func (gcp *GCP) AssociatePrincipal(sa *corev1.ServiceAccount) {
+	sa.Annotations["iam.gke.io/gcp-service-account"] = gcp.GetPrincipal(sa)
 }
 
 func (gcp *GCP) region() string {

--- a/internal/cloud/gcp_test.go
+++ b/internal/cloud/gcp_test.go
@@ -1,0 +1,48 @@
+package cloud_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/sethvargo/go-envconfig"
+	"github.com/stretchr/testify/require"
+	"github.com/substratusai/substratus/internal/cloud"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGCP(t *testing.T) {
+	var gcp cloud.GCP
+	expectedPrincipal := "substratus@my-project.iam.gserviceaccount.com"
+	os.Setenv("CLUSTER_NAME", "my-cluster")
+	os.Setenv("ARTIFACT_BUCKET_URL", "gs://my-artifact-bucket")
+	os.Setenv("REGISTRY_URL", "gcr.io/my-project")
+	os.Setenv("PRINCIPAL", "substratus@my-project.iam.gserviceaccount.com")
+	os.Setenv("PROJECT_ID", "my-project")
+	os.Setenv("CLUSTER_LOCATION", "us-central1")
+
+	require.Error(t, validator.New().Struct(&gcp))
+	require.NoError(t, envconfig.Process(context.Background(), &gcp))
+	require.NoError(t, validator.New().Struct(&gcp))
+
+	sa := corev1.ServiceAccount{}
+	actualPrincipal, bound := gcp.GetPrincipal(&sa)
+	require.Equal(t, actualPrincipal, expectedPrincipal)
+	require.Equal(t, bound, false)
+
+	gcp.AssociatePrincipal(&sa)
+	actualPrincipal, bound = gcp.GetPrincipal(&sa)
+	require.Equal(t, actualPrincipal, expectedPrincipal)
+	require.Equal(t, bound, true)
+
+	sa = corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{cloud.GCPWorkloadIdentityLabel: expectedPrincipal},
+		},
+	}
+	actualPrincipal, bound = gcp.GetPrincipal(&sa)
+	require.Equal(t, actualPrincipal, expectedPrincipal)
+	require.Equal(t, bound, true)
+}

--- a/internal/controller/build_reconciler.go
+++ b/internal/controller/build_reconciler.go
@@ -74,7 +74,7 @@ func (r *BuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	defer log.Info("Done reconciling build")
 
 	// Service account used for building and pushing the image.
-	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
+	if result, err := reconcileServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      containerBuilderServiceAccountName,
 			Namespace: obj.GetNamespace(),

--- a/internal/controller/build_reconciler.go
+++ b/internal/controller/build_reconciler.go
@@ -74,7 +74,7 @@ func (r *BuildReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	defer log.Info("Done reconciling build")
 
 	// Service account used for building and pushing the image.
-	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.Client, &corev1.ServiceAccount{
+	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      containerBuilderServiceAccountName,
 			Namespace: obj.GetNamespace(),

--- a/internal/controller/dataset_controller.go
+++ b/internal/controller/dataset_controller.go
@@ -18,6 +18,7 @@ import (
 	apiv1 "github.com/substratusai/substratus/api/v1"
 	"github.com/substratusai/substratus/internal/cloud"
 	"github.com/substratusai/substratus/internal/resources"
+	"github.com/substratusai/substratus/internal/sci"
 )
 
 // DatasetReconciler reconciles a Dataset object.
@@ -28,6 +29,7 @@ type DatasetReconciler struct {
 	*ParamsReconciler
 
 	Cloud cloud.Cloud
+	SCI   sci.ControllerClient
 }
 
 func (r *DatasetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -84,7 +86,7 @@ func (r *DatasetReconciler) reconcileData(ctx context.Context, dataset *apiv1.Da
 	// ServiceAccount for the loader job.
 	// Within the context of GCP, this ServiceAccount will need IAM permissions
 	// to write the GCS bucket containing training data.
-	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.Client, &corev1.ServiceAccount{
+	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dataLoaderServiceAccountName,
 			Namespace: dataset.Namespace,

--- a/internal/controller/dataset_controller.go
+++ b/internal/controller/dataset_controller.go
@@ -86,7 +86,7 @@ func (r *DatasetReconciler) reconcileData(ctx context.Context, dataset *apiv1.Da
 	// ServiceAccount for the loader job.
 	// Within the context of GCP, this ServiceAccount will need IAM permissions
 	// to write the GCS bucket containing training data.
-	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
+	if result, err := reconcileServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dataLoaderServiceAccountName,
 			Namespace: dataset.Namespace,

--- a/internal/controller/dataset_controller_test.go
+++ b/internal/controller/dataset_controller_test.go
@@ -53,7 +53,7 @@ func testDatasetLoad(t *testing.T, dataset *apiv1.Dataset) {
 		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: dataset.Namespace, Name: "data-loader"}, &sa)
 		assert.NoError(t, err, "getting the data loader serviceaccount")
 	}, timeout, interval, "waiting for the data loader serviceaccount to be created")
-	require.Equal(t, "substratus-data-loader@test-project-id.iam.gserviceaccount.com", sa.Annotations["iam.gke.io/gcp-service-account"])
+	require.Equal(t, "substratus@test-project-id.iam.gserviceaccount.com", sa.Annotations["iam.gke.io/gcp-service-account"])
 
 	// Test that a data loader builder Job gets created by the controller.
 	var loaderJob batchv1.Job

--- a/internal/controller/main_test.go
+++ b/internal/controller/main_test.go
@@ -29,6 +29,7 @@ import (
 	apiv1 "github.com/substratusai/substratus/api/v1"
 	"github.com/substratusai/substratus/internal/cloud"
 	"github.com/substratusai/substratus/internal/controller"
+	"github.com/substratusai/substratus/internal/sci"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -82,6 +83,9 @@ func TestMain(m *testing.M) {
 	testCloud.ClusterLocation = "us-central1"
 	testCloud.ArtifactBucketURL = &cloud.BucketURL{Scheme: "gs", Bucket: "test-artifact-bucket"}
 	testCloud.RegistryURL = "registry.test"
+	testCloud.Principal = "substratus@test-project-id.iam.gserviceaccount.com"
+
+	sciClient := &sci.FakeCSIControllerClient{}
 
 	//runtimeMgr, err := controller.NewRuntimeManager(controller.GPUTypeNvidiaL4)
 	//requireNoError(err)
@@ -90,6 +94,7 @@ func TestMain(m *testing.M) {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		Cloud:  testCloud,
+		SCI:    sciClient,
 		ParamsReconciler: &controller.ParamsReconciler{
 			Scheme: mgr.GetScheme(),
 			Client: mgr.GetClient(),
@@ -100,6 +105,7 @@ func TestMain(m *testing.M) {
 		Scheme:    mgr.GetScheme(),
 		Client:    mgr.GetClient(),
 		Cloud:     testCloud,
+		SCI:       sciClient,
 		NewObject: func() controller.BuildableObject { return &apiv1.Model{} },
 		Kind:      "Model",
 	}).SetupWithManager(mgr)
@@ -108,12 +114,14 @@ func TestMain(m *testing.M) {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		Cloud:  testCloud,
+		SCI:    sciClient,
 	}).SetupWithManager(mgr)
 	requireNoError(err)
 	err = (&controller.BuildReconciler{
 		Scheme:    mgr.GetScheme(),
 		Client:    mgr.GetClient(),
 		Cloud:     testCloud,
+		SCI:       sciClient,
 		NewObject: func() controller.BuildableObject { return &apiv1.Server{} },
 		Kind:      "Server",
 	}).SetupWithManager(mgr)
@@ -122,6 +130,7 @@ func TestMain(m *testing.M) {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		Cloud:  testCloud,
+		SCI:    sciClient,
 		ParamsReconciler: &controller.ParamsReconciler{
 			Scheme: mgr.GetScheme(),
 			Client: mgr.GetClient(),
@@ -132,6 +141,7 @@ func TestMain(m *testing.M) {
 		Scheme:    mgr.GetScheme(),
 		Client:    mgr.GetClient(),
 		Cloud:     testCloud,
+		SCI:       sciClient,
 		NewObject: func() controller.BuildableObject { return &apiv1.Notebook{} },
 		Kind:      "Notebook",
 	}).SetupWithManager(mgr)
@@ -140,6 +150,7 @@ func TestMain(m *testing.M) {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 		Cloud:  testCloud,
+		SCI:    sciClient,
 		ParamsReconciler: &controller.ParamsReconciler{
 			Scheme: mgr.GetScheme(),
 			Client: mgr.GetClient(),
@@ -150,6 +161,7 @@ func TestMain(m *testing.M) {
 		Scheme:    mgr.GetScheme(),
 		Client:    mgr.GetClient(),
 		Cloud:     testCloud,
+		SCI:       sciClient,
 		NewObject: func() controller.BuildableObject { return &apiv1.Dataset{} },
 		Kind:      "Dataset",
 	}).SetupWithManager(mgr)
@@ -196,7 +208,7 @@ func testContainerBuild(t *testing.T, obj testObject, kind string) {
 		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: "container-builder"}, &sa)
 		assert.NoError(t, err, "getting the container builder serviceaccount")
 	}, timeout, interval, "waiting for the container builder serviceaccount to be created")
-	require.Equal(t, "substratus-container-builder@test-project-id.iam.gserviceaccount.com", sa.Annotations["iam.gke.io/gcp-service-account"])
+	require.Equal(t, "substratus@test-project-id.iam.gserviceaccount.com", sa.Annotations["iam.gke.io/gcp-service-account"])
 
 	// Test that a container builder Job gets created by the controller.
 	var builderJob batchv1.Job

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -22,6 +22,7 @@ import (
 	apiv1 "github.com/substratusai/substratus/api/v1"
 	"github.com/substratusai/substratus/internal/cloud"
 	"github.com/substratusai/substratus/internal/resources"
+	"github.com/substratusai/substratus/internal/sci"
 )
 
 // ModelReconciler reconciles a Model object.
@@ -32,6 +33,7 @@ type ModelReconciler struct {
 	*ParamsReconciler
 
 	Cloud cloud.Cloud
+	SCI   sci.ControllerClient
 }
 
 type ModelReconcilerConfig struct {
@@ -78,7 +80,7 @@ func (r *ModelReconciler) reconcileModel(ctx context.Context, model *apiv1.Model
 	// Within the context of GCP, this ServiceAccount will need IAM permissions
 	// to read the GCS bucket containing the training data and read and write from
 	// the bucket that contains base model artifacts.
-	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.Client, &corev1.ServiceAccount{
+	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      modellerServiceAccountName,
 			Namespace: model.Namespace,

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -80,7 +80,7 @@ func (r *ModelReconciler) reconcileModel(ctx context.Context, model *apiv1.Model
 	// Within the context of GCP, this ServiceAccount will need IAM permissions
 	// to read the GCS bucket containing the training data and read and write from
 	// the bucket that contains base model artifacts.
-	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
+	if result, err := reconcileServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      modellerServiceAccountName,
 			Namespace: model.Namespace,

--- a/internal/controller/model_controller_test.go
+++ b/internal/controller/model_controller_test.go
@@ -135,7 +135,7 @@ func testModelTrain(t *testing.T, model *apiv1.Model) {
 		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: model.Namespace, Name: "modeller"}, &sa)
 		assert.NoError(t, err, "getting the model trainer serviceaccount")
 	}, timeout, interval, "waiting for the model trainer serviceaccount to be created")
-	require.Equal(t, "substratus-modeller@test-project-id.iam.gserviceaccount.com", sa.Annotations["iam.gke.io/gcp-service-account"])
+	require.Equal(t, "substratus@test-project-id.iam.gserviceaccount.com", sa.Annotations["iam.gke.io/gcp-service-account"])
 
 	// Test that a trainer Job gets created by the controller.
 	var job batchv1.Job

--- a/internal/controller/notebook_controller.go
+++ b/internal/controller/notebook_controller.go
@@ -157,7 +157,7 @@ func (r *NotebookReconciler) reconcileNotebook(ctx context.Context, notebook *ap
 	// ServiceAccount for the model Job.
 	// Within the context of GCP, this ServiceAccount will need IAM permissions
 	// to read the GCS buckets containing the training data and model artifacts.
-	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
+	if result, err := reconcileServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      notebookServiceAccountName,
 			Namespace: notebook.Namespace,

--- a/internal/controller/notebook_controller.go
+++ b/internal/controller/notebook_controller.go
@@ -21,6 +21,7 @@ import (
 	apiv1 "github.com/substratusai/substratus/api/v1"
 	"github.com/substratusai/substratus/internal/cloud"
 	"github.com/substratusai/substratus/internal/resources"
+	"github.com/substratusai/substratus/internal/sci"
 )
 
 // NotebookReconciler reconciles a Notebook object.
@@ -29,6 +30,7 @@ type NotebookReconciler struct {
 	Scheme *runtime.Scheme
 
 	Cloud cloud.Cloud
+	SCI   sci.ControllerClient
 
 	*ParamsReconciler
 }
@@ -155,7 +157,7 @@ func (r *NotebookReconciler) reconcileNotebook(ctx context.Context, notebook *ap
 	// ServiceAccount for the model Job.
 	// Within the context of GCP, this ServiceAccount will need IAM permissions
 	// to read the GCS buckets containing the training data and model artifacts.
-	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.Client, &corev1.ServiceAccount{
+	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      notebookServiceAccountName,
 			Namespace: notebook.Namespace,

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -233,7 +233,7 @@ func (r *ServerReconciler) reconcileServer(ctx context.Context, server *apiv1.Se
 	// ServiceAccount for loading the Model.
 	// Within the context of GCP, this ServiceAccount will need IAM permissions
 	// to read the GCS bucket containing the model.
-	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
+	if result, err := reconcileServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      modelServerServiceAccountName,
 			Namespace: model.Namespace,

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -23,6 +23,7 @@ import (
 	apiv1 "github.com/substratusai/substratus/api/v1"
 	"github.com/substratusai/substratus/internal/cloud"
 	"github.com/substratusai/substratus/internal/resources"
+	"github.com/substratusai/substratus/internal/sci"
 )
 
 // ServerReconciler reconciles a Server object.
@@ -31,6 +32,7 @@ type ServerReconciler struct {
 	Scheme *runtime.Scheme
 
 	Cloud cloud.Cloud
+	SCI   sci.ControllerClient
 
 	// log should be used outside the context of Reconcile()
 	log logr.Logger
@@ -231,7 +233,7 @@ func (r *ServerReconciler) reconcileServer(ctx context.Context, server *apiv1.Se
 	// ServiceAccount for loading the Model.
 	// Within the context of GCP, this ServiceAccount will need IAM permissions
 	// to read the GCS bucket containing the model.
-	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.Client, &corev1.ServiceAccount{
+	if result, err := reconcileCloudServiceAccount(ctx, r.Cloud, r.SCI, r.Client, &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      modelServerServiceAccountName,
 			Namespace: model.Namespace,

--- a/internal/controller/service_accounts.go
+++ b/internal/controller/service_accounts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/substratusai/substratus/internal/cloud"
+	"github.com/substratusai/substratus/internal/sci"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -16,12 +17,31 @@ const (
 	modelServerServiceAccountName      = "model-server"
 	notebookServiceAccountName         = "notebook"
 	dataLoaderServiceAccountName       = "data-loader"
+	identityBoundLabel                 = "substratusai/identity-bound"
 )
 
-func reconcileCloudServiceAccount(ctx context.Context, cloudConfig cloud.Cloud, c client.Client, sa *corev1.ServiceAccount) (result, error) {
+func reconcileCloudServiceAccount(ctx context.Context, cloudConfig cloud.Cloud, sciClient sci.ControllerClient, c client.Client, sa *corev1.ServiceAccount) (result, error) {
+	if sa.Annotations == nil {
+		sa.Annotations = map[string]string{}
+	}
+
 	configureSA := func() error {
-		cloudConfig.AssociateServiceAccount(sa)
+		cloudConfig.AssociatePrincipal(sa)
 		return nil
+	}
+
+	principal := cloudConfig.GetPrincipal(sa)
+	if val, exist := sa.Annotations[identityBoundLabel]; !exist || val != principal {
+		bindIdentityRequest := sci.BindIdentityRequest{
+			Principal:                principal,
+			KubernetesServiceAccount: sa.Name,
+			KubernetesNamespace:      sa.Namespace,
+		}
+		if _, err := sciClient.BindIdentity(ctx, &bindIdentityRequest); err != nil {
+			return result{}, fmt.Errorf("failed bind identity principal %s to K8s SA %s/%s: %w",
+				principal, sa.Namespace, sa.Name, err)
+		}
+		sa.Annotations["identity-bound"] = principal
 	}
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, c, sa, configureSA); err != nil {

--- a/internal/controller/service_accounts.go
+++ b/internal/controller/service_accounts.go
@@ -20,7 +20,7 @@ const (
 	identityBoundLabel                 = "substratusai/identity-bound"
 )
 
-func reconcileCloudServiceAccount(ctx context.Context, cloudConfig cloud.Cloud, sciClient sci.ControllerClient, c client.Client, sa *corev1.ServiceAccount) (result, error) {
+func reconcileServiceAccount(ctx context.Context, cloudConfig cloud.Cloud, sciClient sci.ControllerClient, c client.Client, sa *corev1.ServiceAccount) (result, error) {
 	if sa.Annotations == nil {
 		sa.Annotations = map[string]string{}
 	}

--- a/internal/controller/service_accounts.go
+++ b/internal/controller/service_accounts.go
@@ -41,7 +41,7 @@ func reconcileServiceAccount(ctx context.Context, cloudConfig cloud.Cloud, sciCl
 			return result{}, fmt.Errorf("failed bind identity principal %s to K8s SA %s/%s: %w",
 				principal, sa.Namespace, sa.Name, err)
 		}
-		sa.Annotations["identity-bound"] = principal
+		sa.Annotations[identityBoundLabel] = principal
 	}
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, c, sa, configureSA); err != nil {

--- a/internal/controller/service_accounts.go
+++ b/internal/controller/service_accounts.go
@@ -17,7 +17,6 @@ const (
 	modelServerServiceAccountName      = "model-server"
 	notebookServiceAccountName         = "notebook"
 	dataLoaderServiceAccountName       = "data-loader"
-	identityBoundLabel                 = "substratus.ai/identity-bound"
 )
 
 func reconcileServiceAccount(ctx context.Context, cloudConfig cloud.Cloud, sciClient sci.ControllerClient, c client.Client, sa *corev1.ServiceAccount) (result, error) {
@@ -30,8 +29,8 @@ func reconcileServiceAccount(ctx context.Context, cloudConfig cloud.Cloud, sciCl
 		return nil
 	}
 
-	principal := cloudConfig.GetPrincipal(sa)
-	if val, exist := sa.Annotations[identityBoundLabel]; !exist || val != principal {
+	principal, bound := cloudConfig.GetPrincipal(sa)
+	if !bound {
 		bindIdentityRequest := sci.BindIdentityRequest{
 			Principal:                principal,
 			KubernetesServiceAccount: sa.Name,
@@ -41,7 +40,6 @@ func reconcileServiceAccount(ctx context.Context, cloudConfig cloud.Cloud, sciCl
 			return result{}, fmt.Errorf("failed bind identity principal %s to K8s SA %s/%s: %w",
 				principal, sa.Namespace, sa.Name, err)
 		}
-		sa.Annotations[identityBoundLabel] = principal
 	}
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, c, sa, configureSA); err != nil {

--- a/internal/controller/service_accounts.go
+++ b/internal/controller/service_accounts.go
@@ -17,7 +17,7 @@ const (
 	modelServerServiceAccountName      = "model-server"
 	notebookServiceAccountName         = "notebook"
 	dataLoaderServiceAccountName       = "data-loader"
-	identityBoundLabel                 = "substratusai/identity-bound"
+	identityBoundLabel                 = "substratus.ai/identity-bound"
 )
 
 func reconcileServiceAccount(ctx context.Context, cloudConfig cloud.Cloud, sciClient sci.ControllerClient, c client.Client, sa *corev1.ServiceAccount) (result, error) {

--- a/internal/sci/fake_sci_client.go
+++ b/internal/sci/fake_sci_client.go
@@ -1,0 +1,21 @@
+package sci
+
+import (
+	context "context"
+
+	grpc "google.golang.org/grpc"
+)
+
+type FakeCSIControllerClient struct{}
+
+func (c *FakeCSIControllerClient) CreateSignedURL(ctx context.Context, in *CreateSignedURLRequest, opts ...grpc.CallOption) (*CreateSignedURLResponse, error) {
+	return &CreateSignedURLResponse{}, nil
+}
+
+func (c *FakeCSIControllerClient) GetObjectMd5(ctx context.Context, in *GetObjectMd5Request, opts ...grpc.CallOption) (*GetObjectMd5Response, error) {
+	return &GetObjectMd5Response{}, nil
+}
+
+func (c *FakeCSIControllerClient) BindIdentity(ctx context.Context, in *BindIdentityRequest, opts ...grpc.CallOption) (*BindIdentityResponse, error) {
+	return &BindIdentityResponse{}, nil
+}


### PR DESCRIPTION
* Call sci.BindIdentity to allow a K8s Service account to impersonate an identity
* Created a FakeSCIControllerClient to be able to run tests easily