### PR TITLE
fix dev-run-gcp

### DIFF
--- a/cmd/controllermanager/main.go
+++ b/cmd/controllermanager/main.go
@@ -117,6 +117,7 @@ func main() {
 	// Create a client using the connection
 	sciClient := sci.NewControllerClient(conn)
 
+	// this environment is only set within a container running on K8s
 	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
 		kubernetesClient, err := kubernetes.NewForConfig(mgr.GetConfig())
 		if err != nil {

--- a/cmd/controllermanager/main.go
+++ b/cmd/controllermanager/main.go
@@ -117,14 +117,16 @@ func main() {
 	// Create a client using the connection
 	sciClient := sci.NewControllerClient(conn)
 
-	kubernetesClient, err := kubernetes.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		setupLog.Error(err, "error creating K8s client-go client")
-	}
-	err = controller.AssociatePrincipalSCIServiceAccount(context.Background(), kubernetesClient, cld)
-	if err != nil {
-		setupLog.Error(err, "error associating principal to SCI K8s ServiceAccount")
-		os.Exit(1)
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		kubernetesClient, err := kubernetes.NewForConfig(mgr.GetConfig())
+		if err != nil {
+			setupLog.Error(err, "error creating K8s client-go client")
+		}
+		err = controller.AssociatePrincipalSCIServiceAccount(context.Background(), kubernetesClient, cld)
+		if err != nil {
+			setupLog.Error(err, "error associating principal to SCI K8s ServiceAccount")
+			os.Exit(1)
+		}
 	}
 
 	if err = (&controller.ModelReconciler{


### PR DESCRIPTION
Previously this would fail due to trying to annotate the SCI K8s Service Account which doesn't exist when you run outside of cluster.