### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,7 @@ Checkout the progress of the Model and the Server.
 kubectl get ai
 ```
 
-When they report a `Ready` status, start a port-forward.
+When they report a `Ready` status, start a port-forward. Note: issues with downloading the image can be resolved by ```docker pull substratusai/model-server-basaran```
 
 ```bash
 kubectl port-forward service/facebook-opt-125m-server 8080:8080


### PR DESCRIPTION
My local env had a problem with handling the install from the kubectl apply commands with this error I was able to resolve by doing a docker pull on the image.

```
File /usr/lib/python3.10/urllib/request.py:280, in urlretrieve(url, filename, reporthook, data)
    277                 reporthook(blocknum, bs, size)
    279 if size >= 0 and read < size:
--> 280     raise ContentTooShortError(
    281         "retrieval incomplete: got only %i out of %i bytes"
    282         % (read, size), result)
    284 return result

ContentTooShortError: <urlopen error retrieval incomplete: got only 762613 out of 898822 bytes>

File /usr/lib/python3.10/urllib/request.py:280, in urlretrieve(url, filename, reporthook, data)
    277                 reporthook(blocknum, bs, size)
    279 if size >= 0 and read < size:
--> 280     raise ContentTooShortError(
    281         "retrieval incomplete: got only %i out of %i bytes"
    282         % (read, size), result)
    284 return result

ContentTooShortError: <urlopen error retrieval incomplete: got only 802816 out of 898822 bytes>
```