### PR TITLE
Add env support and remove params from env

### DIFF
--- a/api/v1/dataset_types.go
+++ b/api/v1/dataset_types.go
@@ -11,6 +11,9 @@ type DatasetSpec struct {
 	// Command to run in the container.
 	Command []string `json:"command,omitempty"`
 
+	// Environment variables in the container
+	Env map[string]intstr.IntOrString `json:"env,omitempty"`
+
 	// Image that contains dataset loading code and dependencies.
 	Image *string `json:"image,omitempty"`
 

--- a/api/v1/dataset_types.go
+++ b/api/v1/dataset_types.go
@@ -12,7 +12,7 @@ type DatasetSpec struct {
 	Command []string `json:"command,omitempty"`
 
 	// Environment variables in the container
-	Env map[string]intstr.IntOrString `json:"env,omitempty"`
+	Env map[string]string `json:"env,omitempty"`
 
 	// Image that contains dataset loading code and dependencies.
 	Image *string `json:"image,omitempty"`

--- a/api/v1/model_types.go
+++ b/api/v1/model_types.go
@@ -11,6 +11,9 @@ type ModelSpec struct {
 	// Command to run in the container.
 	Command []string `json:"command,omitempty"`
 
+	// Environment variables in the container
+	Env map[string]intstr.IntOrString `json:"env,omitempty"`
+
 	// Image that contains model code and dependencies.
 	Image *string `json:"image,omitempty"`
 

--- a/api/v1/model_types.go
+++ b/api/v1/model_types.go
@@ -12,7 +12,7 @@ type ModelSpec struct {
 	Command []string `json:"command,omitempty"`
 
 	// Environment variables in the container
-	Env map[string]intstr.IntOrString `json:"env,omitempty"`
+	Env map[string]string `json:"env,omitempty"`
 
 	// Image that contains model code and dependencies.
 	Image *string `json:"image,omitempty"`

--- a/api/v1/notebook_types.go
+++ b/api/v1/notebook_types.go
@@ -11,6 +11,9 @@ type NotebookSpec struct {
 	// Command to run in the container.
 	Command []string `json:"command,omitempty"`
 
+	// Environment variables in the container
+	Env map[string]intstr.IntOrString `json:"env,omitempty"`
+
 	// Suspend should be set to true to stop the notebook (Pod) from running.
 	// This is a pointer to distinguish between explicit false and not specified.
 	Suspend *bool `json:"suspend,omitempty"`

--- a/api/v1/notebook_types.go
+++ b/api/v1/notebook_types.go
@@ -12,7 +12,7 @@ type NotebookSpec struct {
 	Command []string `json:"command,omitempty"`
 
 	// Environment variables in the container
-	Env map[string]intstr.IntOrString `json:"env,omitempty"`
+	Env map[string]string `json:"env,omitempty"`
 
 	// Suspend should be set to true to stop the notebook (Pod) from running.
 	// This is a pointer to distinguish between explicit false and not specified.

--- a/api/v1/server_types.go
+++ b/api/v1/server_types.go
@@ -11,6 +11,9 @@ type ServerSpec struct {
 	// Command to run in the container.
 	Command []string `json:"command,omitempty"`
 
+	// Environment variables in the container
+	Env map[string]intstr.IntOrString `json:"env,omitempty"`
+
 	// Image that contains model serving application and dependencies.
 	Image *string `json:"image,omitempty"`
 

--- a/api/v1/server_types.go
+++ b/api/v1/server_types.go
@@ -12,7 +12,7 @@ type ServerSpec struct {
 	Command []string `json:"command,omitempty"`
 
 	// Environment variables in the container
-	Env map[string]intstr.IntOrString `json:"env,omitempty"`
+	Env map[string]string `json:"env,omitempty"`
 
 	// Image that contains model serving application and dependencies.
 	Image *string `json:"image,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -152,6 +152,13 @@ func (in *DatasetSpec) DeepCopyInto(out *DatasetSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make(map[string]intstr.IntOrString, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(string)
@@ -292,6 +299,13 @@ func (in *ModelSpec) DeepCopyInto(out *ModelSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make(map[string]intstr.IntOrString, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image
 		*out = new(string)
@@ -426,6 +440,13 @@ func (in *NotebookSpec) DeepCopyInto(out *NotebookSpec) {
 		in, out := &in.Command, &out.Command
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make(map[string]intstr.IntOrString, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.Suspend != nil {
 		in, out := &in.Suspend, &out.Suspend
@@ -600,6 +621,13 @@ func (in *ServerSpec) DeepCopyInto(out *ServerSpec) {
 		in, out := &in.Command, &out.Command
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
+		*out = make(map[string]intstr.IntOrString, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 	if in.Image != nil {
 		in, out := &in.Image, &out.Image

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -154,7 +154,7 @@ func (in *DatasetSpec) DeepCopyInto(out *DatasetSpec) {
 	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -301,7 +301,7 @@ func (in *ModelSpec) DeepCopyInto(out *ModelSpec) {
 	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -443,7 +443,7 @@ func (in *NotebookSpec) DeepCopyInto(out *NotebookSpec) {
 	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -624,7 +624,7 @@ func (in *ServerSpec) DeepCopyInto(out *ServerSpec) {
 	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/config/crd/bases/substratus.ai_datasets.yaml
+++ b/config/crd/bases/substratus.ai_datasets.yaml
@@ -113,10 +113,7 @@ spec:
                 type: array
               env:
                 additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  x-kubernetes-int-or-string: true
+                  type: string
                 description: Environment variables in the container
                 type: object
               image:

--- a/config/crd/bases/substratus.ai_datasets.yaml
+++ b/config/crd/bases/substratus.ai_datasets.yaml
@@ -111,6 +111,14 @@ spec:
                 items:
                   type: string
                 type: array
+              env:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
+                description: Environment variables in the container
+                type: object
               image:
                 description: Image that contains dataset loading code and dependencies.
                 type: string

--- a/config/crd/bases/substratus.ai_models.yaml
+++ b/config/crd/bases/substratus.ai_models.yaml
@@ -113,6 +113,14 @@ spec:
                 items:
                   type: string
                 type: array
+              env:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
+                description: Environment variables in the container
+                type: object
               image:
                 description: Image that contains model code and dependencies.
                 type: string

--- a/config/crd/bases/substratus.ai_models.yaml
+++ b/config/crd/bases/substratus.ai_models.yaml
@@ -115,10 +115,7 @@ spec:
                 type: array
               env:
                 additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  x-kubernetes-int-or-string: true
+                  type: string
                 description: Environment variables in the container
                 type: object
               image:

--- a/config/crd/bases/substratus.ai_notebooks.yaml
+++ b/config/crd/bases/substratus.ai_notebooks.yaml
@@ -115,6 +115,14 @@ spec:
                 required:
                 - name
                 type: object
+              env:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
+                description: Environment variables in the container
+                type: object
               image:
                 description: Image that contains notebook and dependencies.
                 type: string

--- a/config/crd/bases/substratus.ai_notebooks.yaml
+++ b/config/crd/bases/substratus.ai_notebooks.yaml
@@ -117,10 +117,7 @@ spec:
                 type: object
               env:
                 additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  x-kubernetes-int-or-string: true
+                  type: string
                 description: Environment variables in the container
                 type: object
               image:

--- a/config/crd/bases/substratus.ai_servers.yaml
+++ b/config/crd/bases/substratus.ai_servers.yaml
@@ -101,6 +101,14 @@ spec:
                 items:
                   type: string
                 type: array
+              env:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  x-kubernetes-int-or-string: true
+                description: Environment variables in the container
+                type: object
               image:
                 description: Image that contains model serving application and dependencies.
                 type: string

--- a/config/crd/bases/substratus.ai_servers.yaml
+++ b/config/crd/bases/substratus.ai_servers.yaml
@@ -103,10 +103,7 @@ spec:
                 type: array
               env:
                 additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  x-kubernetes-int-or-string: true
+                  type: string
                 description: Environment variables in the container
                 type: object
               image:

--- a/examples/falcon-40b/server.yaml
+++ b/examples/falcon-40b/server.yaml
@@ -6,7 +6,9 @@ spec:
   image: substratusai/model-server-basaran
   model:
     name: falcon-40b
+  env:
+    MODEL_LOAD_IN_4BIT: "true"
   resources:
     gpu:
       type: nvidia-l4
-      count: 4
+      count: 1

--- a/examples/falcon-7b-instruct/finetuned-server.yaml
+++ b/examples/falcon-7b-instruct/finetuned-server.yaml
@@ -6,6 +6,8 @@ spec:
   image: substratusai/model-server-basaran
   model:
     name: falcon-7b-instruct-k8s
+  env:
+    MODEL_LOAD_IN_8BIT: "true"
   resources:
     gpu:
       type: nvidia-l4

--- a/examples/falcon-7b-instruct/server-4bit-any-gpu.yaml
+++ b/examples/falcon-7b-instruct/server-4bit-any-gpu.yaml
@@ -6,8 +6,8 @@ spec:
   image: substratusai/model-server-basaran
   model:
     name: falcon-7b-instruct
-  params:
-    load_in_4bit: "true"
+  env:
+    MODEL_LOAD_IN_8BIT: "true"
   resources:
     gpu:
       count: 1

--- a/examples/falcon-7b-instruct/server.yaml
+++ b/examples/falcon-7b-instruct/server.yaml
@@ -6,6 +6,8 @@ spec:
   image: substratusai/model-server-basaran
   model:
     name: falcon-7b-instruct
+  env:
+    MODEL_LOAD_IN_8BIT: "true"
   resources:
     gpu:
       type: nvidia-l4

--- a/examples/llama2-70b/base-model.yaml
+++ b/examples/llama2-70b/base-model.yaml
@@ -4,10 +4,11 @@ metadata:
   name: llama-2-70b
 spec:
   image: substratusai/model-loader-huggingface
+  env:
+    # You would first have to create a secret named `ai` that
+    # has the key `HUGGING_FACE_HUB_TOKEN` set to your token.
+    # E.g. create the secret by running:
+    # kubectl create secret generic ai --from-literal="HUGGING_FACE_HUB_TOKEN=<my-token>
+    HUGGING_FACE_HUB_TOKEN: ${{ secrets.ai.HUGGING_FACE_HUB_TOKEN }}
   params:
     name: meta-llama/Llama-2-70b-hf
-    # Make sure to replace ${HUGGINGFACE_TOKEN} with your token
-    # for example run this to use your own token:
-    # export HUGGINGFACE_TOKEN=replace-me-with-your-token
-    # cat base-model.yaml | envsubst | kubectl apply -f -
-    hugging_face_hub_token: ${HUGGINGFACE_TOKEN}

--- a/examples/llama2-70b/server.yaml
+++ b/examples/llama2-70b/server.yaml
@@ -6,7 +6,9 @@ spec:
   image: substratusai/model-server-basaran
   model:
     name: llama-2-70b
+  env:
+    MODEL_LOAD_IN_4BIT: "true"
   resources:
     gpu:
       type: nvidia-a100
-      count: 2
+      count: 1

--- a/examples/llama2-7b/base-model.yaml
+++ b/examples/llama2-7b/base-model.yaml
@@ -4,10 +4,11 @@ metadata:
   name: llama-2-7b
 spec:
   image: substratusai/model-loader-huggingface
+  env:
+    # You would first have to create a secret named `ai` that
+    # has the key `HUGGING_FACE_HUB_TOKEN` set to your token.
+    # E.g. create the secret by running:
+    # kubectl create secret generic ai --from-literal="HUGGING_FACE_HUB_TOKEN=<my-token>
+    HUGGING_FACE_HUB_TOKEN: ${{ secrets.ai.HUGGING_FACE_HUB_TOKEN }}
   params:
     name: meta-llama/Llama-2-7b-hf
-    # Make sure to replace ${HUGGINGFACE_TOKEN} with your token
-    # for example run this to use your own token:
-    # export HUGGINGFACE_TOKEN=replace-me-with-your-token
-    # cat base-model.yaml | envsubst | kubectl apply -f -
-    hugging_face_hub_token: ${HUGGINGFACE_TOKEN}

--- a/examples/llama2-7b/finetuned-server.yaml
+++ b/examples/llama2-7b/finetuned-server.yaml
@@ -6,6 +6,8 @@ spec:
   image: substratusai/model-server-basaran
   model:
     name: llama-2-7b-k8s
+  env:
+    MODEL_LOAD_IN_8BIT: "true"
   resources:
     gpu:
       type: nvidia-l4

--- a/examples/llama2-7b/server.yaml
+++ b/examples/llama2-7b/server.yaml
@@ -6,6 +6,8 @@ spec:
   image: substratusai/model-server-basaran
   model:
     name: llama-2-7b
+  env:
+    MODEL_LOAD_IN_8BIT: "true"
   resources:
     gpu:
       type: nvidia-l4

--- a/internal/controller/dataset_controller.go
+++ b/internal/controller/dataset_controller.go
@@ -135,7 +135,7 @@ func (r *DatasetReconciler) reconcileData(ctx context.Context, dataset *apiv1.Da
 
 func (r *DatasetReconciler) loadJob(ctx context.Context, dataset *apiv1.Dataset) (*batchv1.Job, error) {
 	const containerName = "load"
-	envVars, err := resolveEnv(ctx, r.Client, dataset.Namespace, dataset.Spec.Env)
+	envVars, err := resolveEnv(dataset.Spec.Env)
 	if err != nil {
 		return nil, fmt.Errorf("resolving env: %w", err)
 	}

--- a/internal/controller/dataset_controller.go
+++ b/internal/controller/dataset_controller.go
@@ -135,6 +135,10 @@ func (r *DatasetReconciler) reconcileData(ctx context.Context, dataset *apiv1.Da
 
 func (r *DatasetReconciler) loadJob(ctx context.Context, dataset *apiv1.Dataset) (*batchv1.Job, error) {
 	const containerName = "load"
+	envVars, err := resolveEnv(ctx, r.Client, dataset.Namespace, dataset.Spec.Env)
+	if err != nil {
+		return nil, fmt.Errorf("resolving env: %w", err)
+	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: dataset.Name + "-data-loader",
@@ -158,7 +162,7 @@ func (r *DatasetReconciler) loadJob(ctx context.Context, dataset *apiv1.Dataset)
 							Name:    containerName,
 							Image:   dataset.GetImage(),
 							Command: dataset.Spec.Command,
-							Env:     paramsToEnv(dataset.Spec.Params),
+							Env:     envVars,
 						},
 					},
 					RestartPolicy: "Never",

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -277,7 +277,7 @@ func (r *ModelReconciler) findModelsForDataset(ctx context.Context, obj client.O
 func (r *ModelReconciler) modellerJob(ctx context.Context, model, baseModel *apiv1.Model, dataset *apiv1.Dataset) (*batchv1.Job, error) {
 	var job *batchv1.Job
 
-	envVars, err := resolveEnv(ctx, r.Client, model.Namespace, model.Spec.Env)
+	envVars, err := resolveEnv(model.Spec.Env)
 	if err != nil {
 		return nil, fmt.Errorf("resolving env: %w", err)
 	}

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -277,6 +277,11 @@ func (r *ModelReconciler) findModelsForDataset(ctx context.Context, obj client.O
 func (r *ModelReconciler) modellerJob(ctx context.Context, model, baseModel *apiv1.Model, dataset *apiv1.Dataset) (*batchv1.Job, error) {
 	var job *batchv1.Job
 
+	envVars, err := resolveEnv(ctx, r.Client, model.Namespace, model.Spec.Env)
+	if err != nil {
+		return nil, fmt.Errorf("resolving env: %w", err)
+	}
+
 	const containerName = "model"
 	job = &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -302,18 +307,7 @@ func (r *ModelReconciler) modellerJob(ctx context.Context, model, baseModel *api
 							Name:    containerName,
 							Image:   model.GetImage(),
 							Command: model.Spec.Command,
-							Env:     paramsToEnv(model.Spec.Params),
-							EnvFrom: []corev1.EnvFromSource{
-								{
-									SecretRef: &corev1.SecretEnvSource{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: "substratus-secrets",
-										},
-										// just trying to return a pointer to true here
-										Optional: func(b bool) *bool { return &b }(true),
-									},
-								},
-							},
+							Env:     envVars,
 						},
 					},
 					RestartPolicy: "Never",

--- a/internal/controller/model_controller.go
+++ b/internal/controller/model_controller.go
@@ -303,6 +303,17 @@ func (r *ModelReconciler) modellerJob(ctx context.Context, model, baseModel *api
 							Image:   model.GetImage(),
 							Command: model.Spec.Command,
 							Env:     paramsToEnv(model.Spec.Params),
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									SecretRef: &corev1.SecretEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "substratus-secrets",
+										},
+										// just trying to return a pointer to true here
+										Optional: func(b bool) *bool { return &b }(true),
+									},
+								},
+							},
 						},
 					},
 					RestartPolicy: "Never",

--- a/internal/controller/notebook_controller.go
+++ b/internal/controller/notebook_controller.go
@@ -317,7 +317,7 @@ func nbPodName(nb *apiv1.Notebook) string {
 func (r *NotebookReconciler) notebookPod(ctx context.Context, notebook *apiv1.Notebook, model *apiv1.Model, dataset *apiv1.Dataset) (*corev1.Pod, error) {
 	const containerName = "notebook"
 
-	envVars, err := resolveEnv(ctx, r.Client, notebook.Namespace, notebook.Spec.Env)
+	envVars, err := resolveEnv(notebook.Spec.Env)
 	if err != nil {
 		return nil, fmt.Errorf("resolving env: %w", err)
 	}

--- a/internal/controller/notebook_controller.go
+++ b/internal/controller/notebook_controller.go
@@ -259,7 +259,7 @@ func (r *NotebookReconciler) reconcileNotebook(ctx context.Context, notebook *ap
 	//	return result{}, fmt.Errorf("failed to apply pvc: %w", err)
 	//}
 
-	pod, err := r.notebookPod(ctx, notebook, model, dataset)
+	pod, err := r.notebookPod(notebook, model, dataset)
 	if err != nil {
 		return result{}, fmt.Errorf("failed to construct pod: %w", err)
 	}
@@ -314,7 +314,7 @@ func nbPodName(nb *apiv1.Notebook) string {
 }
 
 // notebookPod constructs a Pod for the given Notebook.
-func (r *NotebookReconciler) notebookPod(ctx context.Context, notebook *apiv1.Notebook, model *apiv1.Model, dataset *apiv1.Dataset) (*corev1.Pod, error) {
+func (r *NotebookReconciler) notebookPod(notebook *apiv1.Notebook, model *apiv1.Model, dataset *apiv1.Dataset) (*corev1.Pod, error) {
 	const containerName = "notebook"
 
 	envVars, err := resolveEnv(notebook.Spec.Env)

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -112,7 +112,7 @@ func (r *ServerReconciler) findServersForModel(ctx context.Context, obj client.O
 	return reqs
 }
 
-func (r *ServerReconciler) serverDeployment(ctx context.Context, server *apiv1.Server, model *apiv1.Model) (*appsv1.Deployment, error) {
+func (r *ServerReconciler) serverDeployment(server *apiv1.Server, model *apiv1.Model) (*appsv1.Deployment, error) {
 	replicas := int32(1)
 
 	envVars, err := resolveEnv(server.Spec.Env)
@@ -266,7 +266,7 @@ func (r *ServerReconciler) reconcileServer(ctx context.Context, server *apiv1.Se
 		return result{}, fmt.Errorf("failed to apply service: %w", err)
 	}
 
-	deploy, err := r.serverDeployment(ctx, server, &model)
+	deploy, err := r.serverDeployment(server, &model)
 	if err != nil {
 		return result{}, fmt.Errorf("failed to construct deployment: %w", err)
 	}

--- a/internal/controller/server_controller.go
+++ b/internal/controller/server_controller.go
@@ -115,7 +115,7 @@ func (r *ServerReconciler) findServersForModel(ctx context.Context, obj client.O
 func (r *ServerReconciler) serverDeployment(ctx context.Context, server *apiv1.Server, model *apiv1.Model) (*appsv1.Deployment, error) {
 	replicas := int32(1)
 
-	envVars, err := resolveEnv(ctx, r.Client, server.Namespace, server.Spec.Env)
+	envVars, err := resolveEnv(server.Spec.Env)
 	if err != nil {
 		return nil, fmt.Errorf("resolving env: %w", err)
 	}

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -58,18 +59,17 @@ func resolveEnv(ctx context.Context, c client.Client, namespace string, env map[
 	for key, value := range env {
 		var finalValue string = value.String()
 		// Format ${{ secrets.my-name.my-key }} and spaces optional, following syntax of GitHub actions
-		secretRegex := regexp.MustCompile(`\${{ ?secrets\.(.+)\.(.+) ?}}`)
+		secretRegex := regexp.MustCompile(`\${{ *secrets\.(.+)\.(.+) *}}`)
 		if secretRegex.MatchString(value.StrVal) {
 			matches := secretRegex.FindStringSubmatch(value.StrVal)
 			if len(matches) != 3 {
-				fmt.Println("matches", matches)
 				return nil, fmt.Errorf("error parsing environment key %s, expecting format ${{ secrets.name.key }} but got  %v", key, value.StrVal)
 			}
-			secretName := matches[1]
-			secretKeyName := matches[2]
+			secretName := strings.TrimSpace(matches[1])
+			secretKeyName := strings.TrimSpace(matches[2])
 
-			var secret corev1.Secret
-			if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &secret); err != nil {
+			secret := &corev1.Secret{}
+			if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
 				return nil, fmt.Errorf("getting Secret: %w", err)
 			}
 			if secretVal, exists := secret.Data[secretKeyName]; exists {

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -8,8 +8,6 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -53,32 +51,30 @@ func isPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-func resolveEnv(ctx context.Context, c client.Client, namespace string, env map[string]intstr.IntOrString) ([]corev1.EnvVar, error) {
+func resolveEnv(env map[string]string) ([]corev1.EnvVar, error) {
 	envs := []corev1.EnvVar{}
 
 	for key, value := range env {
-		var finalValue string = value.String()
 		// Format ${{ secrets.my-name.my-key }} and spaces optional, following syntax of GitHub actions
 		secretRegex := regexp.MustCompile(`\${{ *secrets\.(.+)\.(.+) *}}`)
-		if secretRegex.MatchString(value.StrVal) {
-			matches := secretRegex.FindStringSubmatch(value.StrVal)
+		if secretRegex.MatchString(value) {
+			matches := secretRegex.FindStringSubmatch(value)
 			if len(matches) != 3 {
-				return nil, fmt.Errorf("error parsing environment key %s, expecting format ${{ secrets.name.key }} but got  %v", key, value.StrVal)
+				return nil, fmt.Errorf("error parsing environment key %s, expecting format ${{ secrets.name.key }} but got  %v", key, value)
 			}
 			secretName := strings.TrimSpace(matches[1])
 			secretKeyName := strings.TrimSpace(matches[2])
 
-			secret := &corev1.Secret{}
-			if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
-				return nil, fmt.Errorf("getting Secret: %w", err)
+			envVarSource := &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+					Key:                  secretKeyName,
+				},
 			}
-			if secretVal, exists := secret.Data[secretKeyName]; exists {
-				finalValue = string(secretVal)
-			} else {
-				return nil, fmt.Errorf("error parsing environment key %s. The key %s did not exist in secret %s", key, secretKeyName, secretName)
-			}
+			envs = append(envs, corev1.EnvVar{Name: key, ValueFrom: envVarSource})
+		} else {
+			envs = append(envs, corev1.EnvVar{Name: key, Value: value})
 		}
-		envs = append(envs, corev1.EnvVar{Name: key, Value: finalValue})
 	}
 	return envs, nil
 }

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -1,70 +1,64 @@
 package controller
 
 import (
-	"context"
 	"reflect"
 	"testing"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_resolveEnv(t *testing.T) {
+	envVarSource := &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "ai"},
+			Key:                  "MYKEY",
+		},
+	}
+
 	testCases := []struct {
-		input    map[string]intstr.IntOrString
+		input    map[string]string
 		expected []corev1.EnvVar
 	}{
 		// Test case with basic strings
-		{map[string]intstr.IntOrString{
-			"TEST": intstr.FromString("test"),
+		{map[string]string{
+			"TEST": "test",
 		}, []corev1.EnvVar{
 			{Name: "TEST", Value: "test"},
 		}},
 
 		// Test case with secret ref
-		{map[string]intstr.IntOrString{
-			"TEST": intstr.FromString("${{ secrets.ai.MYKEY }}"),
+		{map[string]string{
+			"TEST": "${{ secrets.ai.MYKEY }}",
 		}, []corev1.EnvVar{
-			{Name: "TEST", Value: "ai"},
+			{Name: "TEST", ValueFrom: envVarSource},
 		}},
 
 		// Test case with secret ref no spaces
-		{map[string]intstr.IntOrString{
-			"TEST": intstr.FromString("${{secrets.ai.MYKEY}}"),
+		{map[string]string{
+			"TEST": "${{secrets.ai.MYKEY}}",
 		}, []corev1.EnvVar{
-			{Name: "TEST", Value: "ai"},
+			{Name: "TEST", ValueFrom: envVarSource},
 		}},
 
 		// Test case with secret ref some spaces
-		{map[string]intstr.IntOrString{
-			"TEST": intstr.FromString("${{ secrets.ai.MYKEY}}"),
+		{map[string]string{
+			"TEST": "${{ secrets.ai.MYKEY}}",
 		}, []corev1.EnvVar{
-			{Name: "TEST", Value: "ai"},
+			{Name: "TEST", ValueFrom: envVarSource},
 		}},
 
 		// Test case with secret ref some spaces
-		{map[string]intstr.IntOrString{
-			"TEST": intstr.FromString("${{secrets.ai.MYKEY }}"),
+		{map[string]string{
+			"TEST": "${{secrets.ai.MYKEY }}",
 		}, []corev1.EnvVar{
-			{Name: "TEST", Value: "ai"},
+			{Name: "TEST", ValueFrom: envVarSource},
 		}},
 	}
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"},
-		Data:       map[string][]byte{"MYKEY": []byte("ai")},
-	}
-	client := fake.NewClientBuilder().WithObjects(secret).Build()
 
 	for _, tc := range testCases {
 		t.Log("running Test_resolveEnv with input", tc.input)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		actual, err := resolveEnv(ctx, client, "default", tc.input)
+		actual, err := resolveEnv(tc.input)
 		if err != nil {
 			t.Errorf("error with case %v: %v", tc.input, err)
 		}

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -51,12 +51,15 @@ func Test_resolveEnv(t *testing.T) {
 			{Name: "TEST", Value: "ai"},
 		}},
 	}
-	secret := corev1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"},
 		Data:       map[string][]byte{"MYKEY": []byte("ai")},
 	}
-	client := fake.NewClientBuilder().WithObjects(&secret).Build()
+	client := fake.NewClientBuilder().WithObjects(secret).Build()
+
 	for _, tc := range testCases {
+		t.Log("running Test_resolveEnv with input", tc.input)
+
 		actual, err := resolveEnv(context.Background(), client, "default", tc.input)
 		if err != nil {
 			t.Errorf("error with case %v: %v", tc.input, err)

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -1,27 +1,34 @@
 package controller
 
 import (
+	"context"
+	"reflect"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func Test_nextPowOf2(t *testing.T) {
+func Test_resolveEnv(t *testing.T) {
 	testCases := []struct {
-		input    int64
-		expected int64
+		input    map[string]intstr.IntOrString
+		expected []corev1.EnvVar
 	}{
-		{1, 1},
-		{2, 2},
-		{3, 4},
-		{4, 4},
-		{5, 8},
-		{6, 8},
-		{7, 8},
-		{8, 8},
+		{map[string]intstr.IntOrString{
+			"TEST": intstr.FromString("test"),
+		}, []corev1.EnvVar{
+			{Name: "TEST", Value: "test"},
+		}},
 	}
+	client := fake.NewClientBuilder().Build()
 	for _, tc := range testCases {
-		actual := nextPowOf2(tc.input)
-		if actual != tc.expected {
-			t.Errorf("nextPowOf(%d): expected %d, actual %d", tc.input, tc.expected, actual)
+		actual, err := resolveEnv(context.Background(), client, "default", tc.input)
+		if err != nil {
+			t.Errorf("error with case %v: %v", tc.input, err)
+		}
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Errorf("resolveEnv(%v): expected %v, actual %v", tc.input, tc.expected, actual)
 		}
 	}
 }

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +61,10 @@ func Test_resolveEnv(t *testing.T) {
 	for _, tc := range testCases {
 		t.Log("running Test_resolveEnv with input", tc.input)
 
-		actual, err := resolveEnv(context.Background(), client, "default", tc.input)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		actual, err := resolveEnv(ctx, client, "default", tc.input)
 		if err != nil {
 			t.Errorf("error with case %v: %v", tc.input, err)
 		}

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -57,13 +58,8 @@ func Test_resolveEnv(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Log("running Test_resolveEnv with input", tc.input)
-
 		actual, err := resolveEnv(tc.input)
-		if err != nil {
-			t.Errorf("error with case %v: %v", tc.input, err)
-		}
-		if !reflect.DeepEqual(actual, tc.expected) {
-			t.Errorf("resolveEnv(%v): expected %v, actual %v", tc.input, tc.expected, actual)
-		}
+		require.NoErrorf(t, err, "error with case %v: %v", tc.input, err)
+		require.Truef(t, reflect.DeepEqual(actual, tc.expected), "resolveEnv(%v): expected %v, actual %v", tc.input, tc.expected, actual)
 	}
 }

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -15,13 +16,46 @@ func Test_resolveEnv(t *testing.T) {
 		input    map[string]intstr.IntOrString
 		expected []corev1.EnvVar
 	}{
+		// Test case with basic strings
 		{map[string]intstr.IntOrString{
 			"TEST": intstr.FromString("test"),
 		}, []corev1.EnvVar{
 			{Name: "TEST", Value: "test"},
 		}},
+
+		// Test case with secret ref
+		{map[string]intstr.IntOrString{
+			"TEST": intstr.FromString("${{ secrets.ai.MYKEY }}"),
+		}, []corev1.EnvVar{
+			{Name: "TEST", Value: "ai"},
+		}},
+
+		// Test case with secret ref no spaces
+		{map[string]intstr.IntOrString{
+			"TEST": intstr.FromString("${{secrets.ai.MYKEY}}"),
+		}, []corev1.EnvVar{
+			{Name: "TEST", Value: "ai"},
+		}},
+
+		// Test case with secret ref some spaces
+		{map[string]intstr.IntOrString{
+			"TEST": intstr.FromString("${{ secrets.ai.MYKEY}}"),
+		}, []corev1.EnvVar{
+			{Name: "TEST", Value: "ai"},
+		}},
+
+		// Test case with secret ref some spaces
+		{map[string]intstr.IntOrString{
+			"TEST": intstr.FromString("${{secrets.ai.MYKEY }}"),
+		}, []corev1.EnvVar{
+			{Name: "TEST", Value: "ai"},
+		}},
 	}
-	client := fake.NewClientBuilder().Build()
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"},
+		Data:       map[string][]byte{"MYKEY": []byte("ai")},
+	}
+	client := fake.NewClientBuilder().WithObjects(&secret).Build()
 	for _, tc := range testCases {
 		actual, err := resolveEnv(context.Background(), client, "default", tc.input)
 		if err != nil {


### PR DESCRIPTION
Allow setting environment variables directly from the Substratus resources. 

E.g.
```
spec:
  env:
    MY_KEY: value
    SECRETY_SECRET: ${{ secrets.ai.HUGGING_FACE_HUB_TOKEN }}
```

This also removes the functionality of Substratus of setting `PARAM_` environment variables. So this will require updating our images and possibly examples.